### PR TITLE
Settings UI v2 — Overview redesign, theme palette, draggable tabs

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -182,6 +182,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             BookmarksEnabled = true;
             BookmarksUsePluginPages = false;
             BookmarksUseCustomTabs = false;
+            BookmarksAutoCreateCustomTab = false;
+            BookmarksCustomTabJeOwned = false;
 
             // Icon Settings
             UseIcons = true;
@@ -201,6 +203,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             DownloadsPageEnabled = false;
             DownloadsUsePluginPages = false;
             DownloadsUseCustomTabs = false;
+            DownloadsAutoCreateCustomTab = false;
+            DownloadsCustomTabJeOwned = false;
             DownloadsPagePollingEnabled = true;
             DownloadsPollIntervalSeconds = 30;
             DownloadsPageShowIssues = false;
@@ -211,6 +215,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             CalendarPageEnabled = false;
             CalendarUsePluginPages = false;
             CalendarUseCustomTabs = false;
+            CalendarAutoCreateCustomTab = false;
+            CalendarCustomTabJeOwned = false;
             CalendarFirstDayOfWeek = "Monday";
             CalendarTimeFormat = "5pm/5:30pm";
             CalendarHighlightFavorites = false;
@@ -223,6 +229,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             HiddenContentEnabled = false;
             HiddenContentUsePluginPages = false;
             HiddenContentUseCustomTabs = false;
+            HiddenContentAutoCreateCustomTab = false;
+            HiddenContentCustomTabJeOwned = false;
         }
 
         // Jellyfin Enhanced Settings
@@ -388,6 +396,22 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool BookmarksEnabled { get; set; }
         public bool BookmarksUsePluginPages { get; set; }
         public bool BookmarksUseCustomTabs { get; set; }
+        /// <summary>
+        /// When true (and the Custom Tabs plugin is detected with a recognized
+        /// config schema), Jellyfin Enhanced will manage the corresponding
+        /// Custom Tabs entry: creating it when <see cref="BookmarksUseCustomTabs"/>
+        /// is enabled and removing it when disabled. The toggle in the UI is
+        /// only shown when both conditions hold; it is silently ignored otherwise.
+        /// </summary>
+        public bool BookmarksAutoCreateCustomTab { get; set; }
+
+        /// <summary>
+        /// True if Jellyfin Enhanced created the corresponding Custom Tabs entry
+        /// (set when sync ADDs an entry; cleared when sync REMOVES one). Sync uses
+        /// this flag to ensure it never deletes a Custom Tabs entry the admin
+        /// created manually. Hidden field — no UI; managed entirely by saveConfig.
+        /// </summary>
+        public bool BookmarksCustomTabJeOwned { get; set; }
 
         // Icon Settings
         public bool UseIcons { get; set; }
@@ -407,6 +431,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool DownloadsPageEnabled { get; set; }
         public bool DownloadsUsePluginPages { get; set; }
         public bool DownloadsUseCustomTabs { get; set; }
+        public bool DownloadsAutoCreateCustomTab { get; set; }
+        public bool DownloadsCustomTabJeOwned { get; set; }
         public bool DownloadsPagePollingEnabled { get; set; }
         public int DownloadsPollIntervalSeconds { get; set; }
         public bool DownloadsPageShowIssues { get; set; }
@@ -417,6 +443,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool CalendarPageEnabled { get; set; }
         public bool CalendarUseCustomTabs { get; set; }
         public bool CalendarUsePluginPages { get; set; }
+        public bool CalendarAutoCreateCustomTab { get; set; }
+        public bool CalendarCustomTabJeOwned { get; set; }
         public string CalendarFirstDayOfWeek { get; set; }
         public string CalendarTimeFormat { get; set; }
         public bool CalendarHighlightFavorites { get; set; }
@@ -429,6 +457,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool HiddenContentEnabled { get; set; }
         public bool HiddenContentUsePluginPages { get; set; }
         public bool HiddenContentUseCustomTabs { get; set; }
+        public bool HiddenContentAutoCreateCustomTab { get; set; }
+        public bool HiddenContentCustomTabJeOwned { get; set; }
 
         /// <summary>
         /// Returns configured Sonarr instances, falling back to legacy single-instance fields for migration.

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -625,10 +625,8 @@
     width: 18px;
     height: 18px;
     pointer-events: none;
-    /* Black circular plate — matches how the Seerr brand shows its
-       logo in its own dashboard (purple gradient centred on solid
-       black). Per review feedback on PR #569 (comment on this rule).
-       Hides transparent SVG regions from the active-tab accent bg. */
+    /* Black plate hides transparent SVG regions from the active-tab
+       accent bg. */
     background: #000;
     border-radius: 50%;
     padding: 0;
@@ -832,18 +830,12 @@
         feature (e.g., a "Bookmarks" fieldset for bookmarksEnabled, a
         "Seerr Connection Setup" fieldset for jellyseerrEnabled). If
         the fieldset bundles unrelated settings (e.g., "UI Preferences",
-        "External Links", "UI Tweaks"), the toggle should stay plain —
-        otherwise it visually stands out from its unrelated siblings.
+        "External Links", "UI Tweaks"), the toggle should stay plain.
      2. OR the toggle gates an entire tab via SECTION_DEPS (currently
         only jellyseerrEnabled, which also satisfies #1).
 
-   Parent→child dependency signaling for non-master toggles is handled
-   uniformly by the dashed-indent `je-setting-dep` pattern — don't add
-   a toggle here just because it gates sub-settings.
-
-   Uses :has() to target specific known master IDs; modern browsers
-   (Chrome 105+, Safari 15.4+, Firefox 121+) support it, older
-   fallback is the plain checkbox look (still functional). */
+   :has() requires Chrome 105+ / Safari 15.4+ / Firefox 121+; older
+   browsers fall back to the plain checkbox look. */
 .configSection > .checkboxContainer:has(> label > input#downloadsPageEnabled),
 .configSection > .checkboxContainer:has(> label > input#calendarPageEnabled),
 .configSection > .checkboxContainer:has(> label > input#bookmarksEnabled),
@@ -1125,12 +1117,6 @@
     text-decoration: line-through;
     color: var(--je-text-muted);
 }
-/* Belt-and-braces disable for the body — the form controls already
-   carry the HTML `disabled` attribute (see setBodyDisabled in
-   createInstanceCard), but pointer-events:none also blocks click
-   handlers attached via addEventListener (the Remove button's confirm
-   dialog, etc.) and prevents hover/focus states on the card while
-   the instance is off. */
 .arr-instance-disabled > .arr-instance-card-body {
     pointer-events: none;
 }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -147,15 +147,17 @@
     position: sticky;
     top: 0;
     z-index: 1100;
-    /* Neutral translucent overlay — the backdrop-filter blur pulls the
-       underlying theme color through, so this reads correctly on any
-       Jellyfin theme (teal default, purple, red, etc.) rather than
-       hard-coding a grey tint. */
+    padding: 8px 8px 0 8px;
+    margin: -8px -8px 20px -8px;
+    /* Background/blur/shadow applied only when the form is actually
+       scrolled — at scrollTop=0 the header is transparent so the
+       Jellyfin top bar / user avatar underneath stays visible. */
+    transition: background-color 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+.je-sticky-header.je-is-scrolled {
     background: var(--je-overlay-hard);
     backdrop-filter: blur(14px) saturate(150%);
     -webkit-backdrop-filter: blur(14px) saturate(150%);
-    padding: 8px 8px 0 8px;
-    margin: -8px -8px 20px -8px;
     border-bottom: 1px solid color-mix(in srgb, var(--primary-accent-color, #00a4dc) 18%, transparent);
     box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.6);
 }
@@ -265,6 +267,16 @@
     color: var(--primary-accent-color, #00a4dc);
 }
 .sectionTitle .je-legend-icon { vertical-align: -4px; }
+.je-legend-icon-img {
+    width: 20px;
+    height: 20px;
+    margin-right: 8px;
+    vertical-align: -5px;
+    background: #fff;
+    border-radius: 4px;
+    padding: 2px;
+    box-sizing: content-box;
+}
 
 /* Quick Actions grid */
 .je-quick-actions-grid {
@@ -588,6 +600,14 @@
     width: 18px;
     height: 18px;
     pointer-events: none;
+    /* White plate so the brand SVG (which ships with transparent regions)
+       doesn't go see-through when the tab's background flips to the accent
+       color on the active state. Matches the plate treatment used on
+       service-status cards. */
+    background: #fff;
+    border-radius: 4px;
+    padding: 2px;
+    box-sizing: content-box;
 }
 .jellyfin-tab-button .je-tab-icon {
     font-size: 20px !important;
@@ -792,8 +812,6 @@
 .configSection > .checkboxContainer:has(> label > input#randomButtonEnabled),
 .configSection > .checkboxContainer:has(> label > input#arrLinksEnabled),
 .configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled),
-.configSection > .checkboxContainer:has(> label > input#activeStreamsEnabled),
-.configSection > .checkboxContainer:has(> label > input#showUserReviews),
 .configSection > .checkboxContainer:has(> label > input#autoSeasonRequestEnabled),
 .configSection > .checkboxContainer:has(> label > input#autoMovieRequestEnabled),
 .configSection > .checkboxContainer:has(> label > input#qualityTagsEnabled),
@@ -813,8 +831,6 @@
 .configSection > .checkboxContainer:has(> label > input#randomButtonEnabled) label > span,
 .configSection > .checkboxContainer:has(> label > input#arrLinksEnabled) label > span,
 .configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled) label > span,
-.configSection > .checkboxContainer:has(> label > input#activeStreamsEnabled) label > span,
-.configSection > .checkboxContainer:has(> label > input#showUserReviews) label > span,
 .configSection > .checkboxContainer:has(> label > input#autoSeasonRequestEnabled) label > span,
 .configSection > .checkboxContainer:has(> label > input#autoMovieRequestEnabled) label > span,
 .configSection > .checkboxContainer:has(> label > input#qualityTagsEnabled) label > span,
@@ -939,9 +955,10 @@
 }
 .je-details-section > summary::after,
 .je-seerr-details > summary::after {
-    content: "expand_more";
+    content: "chevron_right";
     font-family: "Material Icons";
-    font-size: 22px;
+    font-size: 24px;
+    display: inline-block;
     transition: transform 0.25s ease, color 0.2s ease;
     color: var(--je-text-subtle);
     line-height: 1;
@@ -949,7 +966,7 @@
 }
 .je-details-section[open] > summary::after,
 .je-seerr-details[open] > summary::after {
-    transform: rotate(180deg);
+    transform: rotate(90deg);
     color: var(--primary-accent-color, #00a4dc);
 }
 .je-details-body {
@@ -1180,6 +1197,12 @@
     border-radius: 4px;
     padding: 0 3px;
     box-shadow: 0 0 0 1px rgba(255,200,0,0.25);
+    /* box-decoration-break: clone keeps the highlight inline with surrounding
+       text across line wraps, so the rest of the description doesn't get
+       pushed to a new line when a short match lands at line start. */
+    display: inline;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
 }
 .je-search-match-active {
     background-color: rgba(255,165,0,0.85);
@@ -1392,7 +1415,7 @@ body.je-hide-descriptions .je-tab-intro { display: none !important; }
 }
 .je-arr-action-row > button { width: fit-content; margin: 0; }
 .je-desc-toggle { display: inline-flex; align-items: center; gap: 4px; }
-.je-desc-toggle .material-icons { font-size: 18px !important; }
+.je-desc-toggle .material-icons { font-size: 18px !important; color: var(--je-text-primary, #fff); }
 .je-desc-toggle[aria-pressed="true"] .material-icons { color: var(--primary-accent-color, #00a4dc); }
 .je-desc-toggle-off { opacity: 0.75; }
 .je-desc-toggle-off:hover { opacity: 1; }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -798,13 +798,24 @@
     font-size: 0.9em;
 }
 
-/* Feature-enabler (master-toggle) checkboxes — visually pronounced so
-   the sub-options that follow read as OPTIONS of that feature, not
-   independent peers. Scoped to one PRIMARY toggle per fieldset (the
-   "enable this page/feature entirely" switch). Mid-fieldset mode
-   selectors and sub-feature anchors stay plain — the dashed-indent
-   `je-setting-dep` pattern already signals their parent→child
-   relationships without visually overloading the page.
+/* Feature-enabler (master-toggle) checkboxes — accent left-border +
+   gradient bg + bold label to signal "this toggle masters the feature
+   that this fieldset exists for."
+
+   Criterion for adding an ID here:
+     1. The toggle sits in a fieldset whose whole purpose IS that one
+        feature (e.g., a "Bookmarks" fieldset for bookmarksEnabled, a
+        "Seerr Connection Setup" fieldset for jellyseerrEnabled). If
+        the fieldset bundles unrelated settings (e.g., "UI Preferences",
+        "External Links", "UI Tweaks"), the toggle should stay plain —
+        otherwise it visually stands out from its unrelated siblings.
+     2. OR the toggle gates an entire tab via SECTION_DEPS (currently
+        only jellyseerrEnabled, which also satisfies #1).
+
+   Parent→child dependency signaling for non-master toggles is handled
+   uniformly by the dashed-indent `je-setting-dep` pattern — don't add
+   a toggle here just because it gates sub-settings.
+
    Uses :has() to target specific known master IDs; modern browsers
    (Chrome 105+, Safari 15.4+, Firefox 121+) support it, older
    fallback is the plain checkbox look (still functional). */

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1556,32 +1556,6 @@ body.je-has-introskipper .je-needs-introskipper { display: none !important; }
     }
 }
 
-/* Two-column input pairs — side-by-side input+description blocks on wide
-   viewports, stacking under the mobile breakpoint. Each .je-two-col-pair
-   owns one input and its description so the description sits directly
-   under its input instead of spanning the whole grid. */
-.je-two-col-pairs {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 18px;
-    align-items: start;
-}
-.je-two-col-pair {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    min-width: 0;
-}
-.je-two-col-pair > .inputContainer,
-.je-two-col-pair > .je-setting-description {
-    margin: 0;
-}
-@media (max-width: 720px) {
-    .je-two-col-pairs {
-        grid-template-columns: 1fr;
-    }
-}
-
 /* Custom Tabs auto-manage toggles — hidden by default. Revealed only when
    the Custom Tabs plugin is detected AND its config schema matches what
    Jellyfin Enhanced knows how to write. JS sets `je-has-customtabs-compat`

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1445,22 +1445,30 @@ body.je-hide-descriptions .je-tab-intro { display: none !important; }
     margin-top: 8px;
 }
 .je-arr-action-row > button { width: fit-content; margin: 0; }
-.je-desc-toggle { display: inline-flex; align-items: center; gap: 4px; }
-/* Icons on both header buttons inherit the button's own text color via
-   currentColor. Earlier they carried Jellyfin's `secondaryText` class
-   and (on the Descriptions toggle) a pressed-state accent color — both
-   vanish on themes whose raised-button background is the accent color
-   or uses a secondaryText tone matching its own fill. Using
-   currentColor keeps them readable on every theme, and the Descriptions
-   ON-state is marked instead by a 2px accent ring on the button itself
-   (painted outside the button, so the fill can't mask it). */
-.je-desc-toggle .material-icons,
-.je-help-link .material-icons { color: currentColor; }
-.je-desc-toggle .material-icons { font-size: 18px !important; }
-.je-desc-toggle[aria-pressed="true"] {
-    box-shadow: 0 0 0 2px var(--primary-accent-color, #00a4dc);
+.je-desc-toggle { display: inline-flex; align-items: center; gap: 8px; }
+/* On/Off pill — replaces the earlier Material-icons indicator that
+   vanished on themes whose raised-button fill matches the accent.
+   Pill is a small chip that flips its background between a muted
+   neutral (OFF) and the user's accent color (ON). Always reads
+   against the button because the chip has its own fill. */
+.je-desc-toggle-state {
+    font-size: 0.72em;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: color-mix(in srgb, currentColor 18%, transparent);
+    color: currentColor;
+    line-height: 1.4;
+    min-width: 28px;
+    text-align: center;
 }
-.je-desc-toggle-off { opacity: 0.75; }
+.je-desc-toggle[aria-pressed="true"] .je-desc-toggle-state {
+    background: var(--primary-accent-color, #00a4dc);
+    color: #fff;
+}
+.je-desc-toggle-off { opacity: 0.85; }
 .je-desc-toggle-off:hover { opacity: 1; }
 
 /* ---------------------------------------------------------------------------
@@ -1835,25 +1843,17 @@ body.je-has-filetransformation .je-installed-badge[data-plugin="filetransformati
     }
 }
 
-/* Sub-mobile: hide button labels on the very narrowest viewports so the
-   header stays compact even on iPhone SE / Android Mini. The icon alone
-   stays clickable; `aria-label` + `title` on the button surface the label
-   for assistive tech and on long-press for users who need it. Tap target
-   is bumped to meet WCAG 2.1 AAA (44×44 CSS px). */
+/* Sub-mobile: tighten typography + ensure the buttons stay tappable.
+   Labels stay visible (no icon fallback anymore after the header icons
+   were removed — an icon-less button with a hidden label would render
+   as an empty square). 44×44 min size meets WCAG 2.1 AAA. */
 @media (max-width: 420px) {
-    .je-help-link .je-help-link-label,
-    .je-desc-toggle .je-desc-toggle-label {
-        display: none;
-    }
     .je-help-link,
     .je-desc-toggle {
-        min-width: 44px;
         min-height: 44px;
-        padding: 10px;
-        justify-content: center;
+        padding: 8px 12px;
+        font-size: 0.82em;
     }
-    .je-help-link .material-icons,
-    .je-desc-toggle .material-icons { font-size: 20px !important; }
     .sectionTitleContainer h2 { font-size: 1.25em; }
 }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -43,15 +43,6 @@
     --je-accent-tint-10: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 10%, transparent);
     --je-accent-tint-20: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 20%, transparent);
     --je-accent-border:  color-mix(in srgb, var(--primary-accent-color, #00a4dc) 40%, transparent);
-    /* Icon plate — the small background under brand SVGs (Seerr tab
-       icon, Sonarr/Radarr/Bazarr legend icons) so their transparent
-       regions don't bleed through the underlying surface (especially
-       the accent color on an active tab). Soft off-white in dark
-       themes; dark plate in .je-light-theme below (otherwise the
-       white-bodied Sonarr/Bazarr logos merge into the light page
-       background). */
-    --je-icon-plate-bg:      rgba(255, 255, 255, 0.94);
-    --je-icon-plate-shadow:  0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
 #JellyfinEnhancedPage.je-light-theme {
@@ -73,12 +64,6 @@
     --je-overlay-soft:   rgba(0, 0, 0, 0.06);
     --je-overlay:        rgba(0, 0, 0, 0.1);
     --je-overlay-hard:   rgba(0, 0, 0, 0.35);
-    /* Dark plate on light theme — white-bodied Sonarr/Bazarr logos
-       would merge into a light-theme page without this. Picks up a
-       small amount of the user's accent so the plate harmonizes
-       instead of reading as a stark dark chip. */
-    --je-icon-plate-bg:      color-mix(in srgb, var(--primary-accent-color, #00a4dc) 18%, #1a202c);
-    --je-icon-plate-shadow:  0 1px 2px rgba(0, 0, 0, 0.18);
 }
 
 /* OS-level light preference as a fallback: only kicks in when the JS
@@ -104,8 +89,6 @@
         --je-overlay-soft:   rgba(0, 0, 0, 0.06);
         --je-overlay:        rgba(0, 0, 0, 0.1);
         --je-overlay-hard:   rgba(0, 0, 0, 0.35);
-        --je-icon-plate-bg:      color-mix(in srgb, var(--primary-accent-color, #00a4dc) 18%, #1a202c);
-        --je-icon-plate-shadow:  0 1px 2px rgba(0, 0, 0, 0.18);
     }
 }
 
@@ -314,14 +297,10 @@
     height: 20px;
     margin-right: 8px;
     vertical-align: -5px;
-    /* Same theme-aware plate as the tab icons (see --je-icon-plate-bg
-       definition near the top of this file) — keeps Sonarr/Radarr/
-       Bazarr brand logos legible on both dark and light themes. */
-    background: var(--je-icon-plate-bg);
-    border-radius: 4px;
-    padding: 2px;
-    box-sizing: content-box;
-    box-shadow: var(--je-icon-plate-shadow);
+    /* No plate: the Sonarr/Radarr/Bazarr brand SVGs already carry
+       their own solid backgrounds in-file (rounded squircle for
+       Sonarr, circle for Radarr, circle for Bazarr) so an extra
+       plate reads as a double-backing. */
 }
 
 /* Quick Actions grid */
@@ -646,16 +625,14 @@
     width: 18px;
     height: 18px;
     pointer-events: none;
-    /* Brand SVGs ship with transparent regions; without a plate, the
-       active-tab accent background bleeds through those gaps. Plate
-       color is theme-aware: off-white on dark themes, dark accent-
-       tinted on .je-light-theme. Soft drop-shadow gives depth so the
-       chip doesn't read as a stark stamp. */
-    background: var(--je-icon-plate-bg);
-    border-radius: 4px;
-    padding: 2px;
+    /* Black circular plate — matches how the Seerr brand shows its
+       logo in its own dashboard (purple gradient centred on solid
+       black). Per review feedback on PR #569 (comment on this rule).
+       Hides transparent SVG regions from the active-tab accent bg. */
+    background: #000;
+    border-radius: 50%;
+    padding: 0;
     box-sizing: content-box;
-    box-shadow: var(--je-icon-plate-shadow);
 }
 .jellyfin-tab-button .je-tab-icon {
     font-size: 20px !important;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1446,15 +1446,17 @@ body.je-hide-descriptions .je-tab-intro { display: none !important; }
 }
 .je-arr-action-row > button { width: fit-content; margin: 0; }
 .je-desc-toggle { display: inline-flex; align-items: center; gap: 4px; }
-/* Icon always inherits the button's own text color via currentColor —
-   earlier the pressed state used `var(--primary-accent-color)` which
-   vanishes on themes whose raised-button background also uses the
-   accent color (any "Jellyfish"-style accent-filled button theme).
-   Use the button label's color for the icon so it stays visible on
-   every theme, and mark the pressed state with an accent ring on the
-   button itself — the ring reads against any bg because it's painted
-   outside the button. */
-.je-desc-toggle .material-icons { font-size: 18px !important; color: currentColor; }
+/* Icons on both header buttons inherit the button's own text color via
+   currentColor. Earlier they carried Jellyfin's `secondaryText` class
+   and (on the Descriptions toggle) a pressed-state accent color — both
+   vanish on themes whose raised-button background is the accent color
+   or uses a secondaryText tone matching its own fill. Using
+   currentColor keeps them readable on every theme, and the Descriptions
+   ON-state is marked instead by a 2px accent ring on the button itself
+   (painted outside the button, so the fill can't mask it). */
+.je-desc-toggle .material-icons,
+.je-help-link .material-icons { color: currentColor; }
+.je-desc-toggle .material-icons { font-size: 18px !important; }
 .je-desc-toggle[aria-pressed="true"] {
     box-shadow: 0 0 0 2px var(--primary-accent-color, #00a4dc);
 }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1,6 +1,119 @@
 /* =============================================================================
-   Jellyfin Enhanced — Config Page Stylesheet
+   Jellyfin Enhanced — Config Page Stylesheet (Modernized)
    ============================================================================= */
+
+/* ---------------------------------------------------------------------------
+   Theme-aware surface palette
+   ---------------------------------------------------------------------------
+   Jellyfin ships multiple themes (Dark, Pumpkin, Light, WMC, Blue Radiance,
+   Apple TV, Purple Haze). Each swaps a whole theme.css at runtime with
+   hardcoded colors — no CSS-variable contract we can rely on. So we define
+   our own small palette below, with dark defaults and a `.je-light-theme`
+   override block that kicks in when a tiny JS detector at page load decides
+   the current theme has a light body. `@media (prefers-color-scheme: light)`
+   acts as a secondary fallback for browser-level preferences.
+   --------------------------------------------------------------------------- */
+#JellyfinEnhancedPage {
+    /* Surface lift layers — slightly lighter than body bg */
+    --je-surface-1:      rgba(255, 255, 255, 0.03);
+    --je-surface-2:      rgba(255, 255, 255, 0.05);
+    --je-surface-3:      rgba(255, 255, 255, 0.08);
+    --je-surface-hover:  rgba(255, 255, 255, 0.08);
+    /* Borders */
+    --je-border-subtle:  rgba(255, 255, 255, 0.04);
+    --je-border:         rgba(255, 255, 255, 0.08);
+    --je-border-strong:  rgba(255, 255, 255, 0.12);
+    --je-border-focus:   rgba(255, 255, 255, 0.2);
+    /* Text — `inherit` stays legible under any theme's <html> color */
+    --je-text:           inherit;
+    --je-text-strong:    rgba(255, 255, 255, 0.87);
+    --je-text-muted:     rgba(255, 255, 255, 0.6);
+    --je-text-subtle:    rgba(255, 255, 255, 0.45);
+    --je-text-dim:       rgba(255, 255, 255, 0.3);
+    /* Subtle decorative gradients for card surfaces (light shine → transparent).
+       Swap to dark shine on light themes so cards keep a faint lift. */
+    --je-card-gradient:       linear-gradient(145deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.02) 100%);
+    --je-card-gradient-lift:  linear-gradient(145deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0.03) 100%);
+    --je-legend-gradient:     linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.02) 100%);
+    /* Dark overlays for intentionally-dark modals (preview panel, toasts) */
+    --je-overlay-soft:   rgba(0, 0, 0, 0.12);
+    --je-overlay:        rgba(0, 0, 0, 0.28);
+    --je-overlay-hard:   rgba(0, 0, 0, 0.55);
+    /* Accent tints (already theme-adapting via --primary-accent-color) */
+    --je-accent-tint-10: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 10%, transparent);
+    --je-accent-tint-20: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 20%, transparent);
+    --je-accent-border:  color-mix(in srgb, var(--primary-accent-color, #00a4dc) 40%, transparent);
+}
+
+#JellyfinEnhancedPage.je-light-theme {
+    --je-surface-1:      rgba(0, 0, 0, 0.025);
+    --je-surface-2:      rgba(0, 0, 0, 0.05);
+    --je-surface-3:      rgba(0, 0, 0, 0.08);
+    --je-surface-hover:  rgba(0, 0, 0, 0.08);
+    --je-border-subtle:  rgba(0, 0, 0, 0.06);
+    --je-border:         rgba(0, 0, 0, 0.1);
+    --je-border-strong:  rgba(0, 0, 0, 0.15);
+    --je-border-focus:   rgba(0, 0, 0, 0.25);
+    --je-text-strong:    rgba(0, 0, 0, 0.87);
+    --je-text-muted:     rgba(0, 0, 0, 0.65);
+    --je-text-subtle:    rgba(0, 0, 0, 0.5);
+    --je-text-dim:       rgba(0, 0, 0, 0.35);
+    --je-card-gradient:       linear-gradient(145deg, rgba(0, 0, 0, 0.03) 0%, rgba(0, 0, 0, 0.01) 100%);
+    --je-card-gradient-lift:  linear-gradient(145deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0.015) 100%);
+    --je-legend-gradient:     linear-gradient(180deg, rgba(0, 0, 0, 0.02) 0%, rgba(0, 0, 0, 0.01) 100%);
+    --je-overlay-soft:   rgba(0, 0, 0, 0.06);
+    --je-overlay:        rgba(0, 0, 0, 0.1);
+    --je-overlay-hard:   rgba(0, 0, 0, 0.35);
+}
+
+/* OS-level light preference as a fallback: only kicks in when the JS
+   detector hasn't explicitly declared the page dark (to let Jellyfin's
+   user-selected dark themes stay dark even on a light OS). */
+@media (prefers-color-scheme: light) {
+    #JellyfinEnhancedPage:not(.je-dark-theme):not(.je-light-theme) {
+        --je-surface-1:      rgba(0, 0, 0, 0.025);
+        --je-surface-2:      rgba(0, 0, 0, 0.05);
+        --je-surface-3:      rgba(0, 0, 0, 0.08);
+        --je-surface-hover:  rgba(0, 0, 0, 0.08);
+        --je-border-subtle:  rgba(0, 0, 0, 0.06);
+        --je-border:         rgba(0, 0, 0, 0.1);
+        --je-border-strong:  rgba(0, 0, 0, 0.15);
+        --je-border-focus:   rgba(0, 0, 0, 0.25);
+        --je-text-strong:    rgba(0, 0, 0, 0.87);
+        --je-text-muted:     rgba(0, 0, 0, 0.65);
+        --je-text-subtle:    rgba(0, 0, 0, 0.5);
+        --je-text-dim:       rgba(0, 0, 0, 0.35);
+        --je-card-gradient:       linear-gradient(145deg, rgba(0, 0, 0, 0.03) 0%, rgba(0, 0, 0, 0.01) 100%);
+        --je-card-gradient-lift:  linear-gradient(145deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0.015) 100%);
+        --je-legend-gradient:     linear-gradient(180deg, rgba(0, 0, 0, 0.02) 0%, rgba(0, 0, 0, 0.01) 100%);
+        --je-overlay-soft:   rgba(0, 0, 0, 0.06);
+        --je-overlay:        rgba(0, 0, 0, 0.1);
+        --je-overlay-hard:   rgba(0, 0, 0, 0.35);
+    }
+}
+
+/* ---------------------------------------------------------------------------
+   Base Form Container & Typography
+   --------------------------------------------------------------------------- */
+#JellyfinEnhancedPage {
+    color: inherit;
+    font-family: inherit;
+}
+
+/* Override Jellyfin admin's `.content-primary form { max-width: ~803px }`
+   default. The page-id prefix gives us higher specificity than the
+   admin theme, so we don't need !important.
+   Cap at 2400px so the tab grid (auto-fit, minmax(480px, 1fr)) can fit
+   4-5 cards on ultrawide while preventing single-row content (Overview's
+   status dashboard, Integration Health, Quick Actions — all of which span
+   `grid-column: 1 / -1`) from stretching across a 4K/5K viewport at a
+   single huge column. 2400px = 4 full cards at 480px wide + gaps. */
+#JellyfinEnhancedPage #JellyfinEnhancedForm {
+    max-width: 2400px;
+    width: 100%;
+    margin: 0 auto;
+    padding-bottom: 120px; /* Space for sticky footer */
+}
 
 /* ---------------------------------------------------------------------------
    Animations
@@ -12,1118 +125,1790 @@
     30%, 50%, 70% { transform: translate3d(-4px, 0, 0); }
     40%, 60% { transform: translate3d(4px, 0, 0); }
 }
+@keyframes slideUpFade {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
 
 .status-check { animation: spin 1s linear infinite; }
 .shake { animation: shake 0.82s cubic-bezier(.36,.07,.19,.97) both; }
 
 /* ---------------------------------------------------------------------------
-   Tab navigation
+   Sticky header region — title + search + tab bar stay pinned at the
+   viewport top; only the form content scrolls.
+   Jellyfin's `[data-role="content"]` ancestor sets `overflow: hidden`
+   which kills `position: sticky`. Override that ancestor (scoped to
+   our page) so sticky works on window scroll.
    --------------------------------------------------------------------------- */
-.jellyfin-tab-button {
-    position: relative;
-    z-index: 1000;
-    background: none;
-    border: none;
-    color: #ccc;
-    cursor: pointer;
-    transition: color 0.3s, border-bottom 0.3s;
-    border-bottom: 2px solid transparent;
+#JellyfinEnhancedPage[data-role="page"] > [data-role="content"] {
+    overflow: visible;
 }
-.jellyfin-tab-button.active {
-    color: var(--primary-accent-color, #fff);
-    border-bottom-color: var(--primary-accent-color, #fff);
-}
-.jellyfin-tab-button h3,
-.jellyfin-tab-button img {
-    pointer-events: none;
-}
-.jellyfin-tab-button img {
-    width: 20px;
-    height: 20px;
-    margin-right: 8px;
-    vertical-align: middle;
-    filter: brightness(0.8);
-}
-
-.jellyfin-tab-content {
-    display: none;
-    font-family: inherit;
-}
-.jellyfin-tab-content.active {
-    display: block;
+.je-sticky-header {
+    position: sticky;
+    top: 0;
+    z-index: 1100;
+    /* Neutral translucent overlay — the backdrop-filter blur pulls the
+       underlying theme color through, so this reads correctly on any
+       Jellyfin theme (teal default, purple, red, etc.) rather than
+       hard-coding a grey tint. */
+    background: var(--je-overlay-hard);
+    backdrop-filter: blur(14px) saturate(150%);
+    -webkit-backdrop-filter: blur(14px) saturate(150%);
+    padding: 8px 8px 0 8px;
+    margin: -8px -8px 20px -8px;
+    border-bottom: 1px solid color-mix(in srgb, var(--primary-accent-color, #00a4dc) 18%, transparent);
+    box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.6);
 }
 
 /* ---------------------------------------------------------------------------
-   Settings search bar
+   Header & Search Bar
    --------------------------------------------------------------------------- */
+.sectionTitleContainer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin-bottom: 0;
+    padding: 10px 0 10px 0;
+    border-bottom: 1px solid var(--je-border);
+}
+.sectionTitleContainer h2 {
+    font-size: 1.8em;
+    font-weight: 600;
+    margin: 0;
+}
+.je-header-title-row {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
 #settingsSearchContainer {
-    margin-left: auto;
-    min-width: 200px;
-    max-width: 320px;
+    min-width: 260px;
+    max-width: 350px;
     flex: 1;
 }
 #settingsSearchContainer > div {
     position: relative;
+    display: flex;
+    align-items: center;
 }
 #settingsSearchInput {
     width: 100%;
-    padding: 0.45em 2.2em 0.45em 2.2em;
-    background: rgba(255,255,255,0.08);
-    border: 1px solid rgba(255,255,255,0.15);
-    border-radius: 6px;
+    padding: 10px 90px 10px 35px !important; /* Pad right to fit count and clear btn */
+    background: var(--je-overlay);
+    border: 1px solid var(--je-border);
+    border-radius: 20px;
     color: #eee;
-    font-size: 0.85em;
+    font-size: 0.9em;
     outline: none;
+    transition: all 0.3s ease;
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.1);
     box-sizing: border-box;
+}
+#settingsSearchInput:focus {
+    background: var(--je-overlay-hard);
+    border-color: var(--primary-accent-color, #00a4dc);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-accent-color, #00a4dc) 20%, transparent);
+}
+.je-search-icon {
+    position: absolute;
+    left: 10px;
+    color: var(--je-text-subtle);
+    pointer-events: none;
+    font-size: 1.2em;
 }
 #settingsSearchCount {
     display: none;
     position: absolute;
-    right: 2.4em;
-    top: 50%;
-    transform: translateY(-50%);
-    color: rgba(255,255,255,0.4);
-    font-size: 0.75em;
-    white-space: nowrap;
+    right: 40px;
+    color: var(--je-text-muted);
+    font-size: 0.8em;
+    font-weight: 500;
 }
 #settingsSearchClear {
     display: none;
     position: absolute;
-    right: 0.4em;
-    top: 50%;
-    transform: translateY(-50%);
-    background: none;
+    right: 10px;
+    background: var(--je-surface-3);
     border: none;
-    color: rgba(255,255,255,0.5);
+    color: #fff;
     cursor: pointer;
-    padding: 0.2em;
-    font-size: 1em;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    font-size: 0.8em;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s;
+}
+#settingsSearchClear:hover {
+    background: #dc3545;
+}
+
+/* ---------------------------------------------------------------------------
+   Overview Tab — Service Status, Quick Actions
+   --------------------------------------------------------------------------- */
+.je-overview-section {
+    margin-bottom: 20px;
+}
+.je-overview-section > .configSection {
+    padding: 14px 18px;
+}
+.je-legend-icon {
+    font-size: 20px !important;
+    line-height: 1;
+    vertical-align: middle;
+    margin-right: 8px;
+    opacity: 0.75;
+    color: var(--primary-accent-color, #00a4dc);
+}
+.sectionTitle .je-legend-icon { vertical-align: -4px; }
+
+/* Quick Actions grid */
+.je-quick-actions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 12px;
+}
+.je-quick-action {
+    background: var(--je-card-gradient);
+    border: 1px solid var(--je-border);
+    border-radius: 12px;
+    padding: 14px 16px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    cursor: pointer;
+    color: inherit;
+    text-align: left;
+    transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+    font: inherit;
+    width: 100%;
+}
+.je-quick-action:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+    border-color: var(--je-text-dim);
+    background: var(--je-card-gradient-lift);
+}
+.je-quick-action:focus-visible {
+    outline: 2px solid var(--primary-accent-color, #00a4dc);
+    outline-offset: 2px;
+}
+.je-quick-action-icon {
+    font-size: 26px !important;
+    color: var(--primary-accent-color, #00a4dc);
+    flex-shrink: 0;
+}
+.je-quick-action-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+.je-quick-action-title {
+    font-size: 0.95em;
+    font-weight: 600;
+}
+.je-quick-action-detail {
+    font-size: 0.8em;
+    opacity: 0.65;
+    line-height: 1.3;
+}
+
+/* Empty-state hint shared by Service Status, Features, and Optional
+   Dependencies renderers when they have nothing to show. */
+.je-checklist-empty {
+    padding: 14px 16px;
+    border: 1px dashed var(--je-border);
+    border-radius: 10px;
+    color: #888;
+    font-size: 0.9em;
+    text-align: center;
+}
+
+/* ---------------------------------------------------------------------------
+   Overview Tab — Service Status (merged from legacy status cards + checklist)
+   Mirrors the Optional Dependencies / Features look: card grid with a
+   left-border accent per state, icon + name + detail. Clickable rows jump
+   to the owning tab.
+   --------------------------------------------------------------------------- */
+.je-service-dashboard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 10px;
+}
+.je-service-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px;
+    background: var(--je-surface-1);
+    border: 1px solid var(--je-border);
+    border-left-width: 3px;
+    border-radius: 10px;
+    cursor: pointer;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    transition: background 0.15s ease, transform 0.15s ease;
+}
+.je-service-card:hover { background: var(--je-surface-2); transform: translateY(-1px); }
+.je-service-card.je-state-ok       { border-left-color: #4caf50; }
+.je-service-card.je-state-warn     { border-left-color: #ff9800; }
+.je-service-card.je-state-error    { border-left-color: #f44336; }
+.je-service-card.je-state-pending  { border-left-color: var(--je-text-dim); }
+.je-service-card.je-state-off      { border-left-color: var(--je-border-strong); opacity: 0.55; }
+.je-service-icon {
+    font-size: 20px !important;
+    color: var(--je-text-muted);
+    flex-shrink: 0;
+}
+.je-service-card.je-state-ok    .je-service-icon { color: #4caf50; }
+.je-service-card.je-state-warn  .je-service-icon { color: #ff9800; }
+.je-service-card.je-state-error .je-service-icon { color: #f44336; }
+.je-service-body {
+    min-width: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+.je-service-name {
+    font-size: 0.92em;
+    font-weight: 600;
+}
+.je-service-detail {
+    font-size: 0.78em;
+    color: var(--je-text-muted);
+    line-height: 1.35;
+    word-break: break-word;
+}
+
+@media (max-width: 540px) {
+    .je-service-dashboard { grid-template-columns: 1fr; }
+    .je-service-card { padding: 10px; }
+}
+
+/* ---------------------------------------------------------------------------
+   Overview Tab — Optional Dependencies grid
+   --------------------------------------------------------------------------- */
+.je-optional-plugins-dashboard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+}
+.je-optional-plugin-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px;
+    background: var(--je-surface-1);
+    border: 1px solid var(--je-border);
+    border-left-width: 3px;
+    border-left-color: var(--je-border-strong);
+    border-radius: 10px;
+    position: relative;
+}
+.je-optional-plugin-link {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    color: var(--je-text-subtle);
+    opacity: 0.7;
+    text-decoration: none;
+    transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.je-optional-plugin-link:hover,
+.je-optional-plugin-link:focus-visible {
+    opacity: 1;
+    color: var(--primary-accent-color, #00a4dc);
+    background: var(--je-accent-tint-10);
+    outline: none;
+}
+.je-optional-plugin-link .material-icons {
+    font-size: 16px !important;
     line-height: 1;
 }
-
-/* ---------------------------------------------------------------------------
-   Search highlight utilities
-   --------------------------------------------------------------------------- */
-.je-search-hidden { display: none !important; }
-
-.je-search-match {
-    background-color: rgba(255,200,0,0.35);
-    color: #fff;
-    border-radius: 2px;
-    padding: 0 1px;
-    box-shadow: 0 0 0 1px rgba(255,200,0,0.25);
+.je-optional-plugin-body {
+    padding-right: 28px;
 }
-.je-search-match-active {
-    background-color: rgba(255,165,0,0.75);
-    box-shadow: 0 0 0 2px rgba(255,165,0,0.5);
-}
-.je-search-tab-label {
-    font-size: 1.15em;
-    font-weight: bold;
-    color: var(--primary-accent-color, #00a4dc);
-    margin-bottom: 0.5em;
-    padding: 0.4em 0;
-    border-bottom: 1px solid rgba(255,255,255,0.1);
-}
-
-/* ---------------------------------------------------------------------------
-   Dependency hints / banners
-   --------------------------------------------------------------------------- */
-.dep-hint-text {
-    display: block;
-    font-size: 0.8em;
-    color: #ff9800;
+.je-optional-plugin-card.je-state-installed  { border-left-color: #4caf50; }
+.je-optional-plugin-card.je-state-missing    { border-left-color: var(--je-border-strong); opacity: 0.75; }
+.je-optional-plugin-card.je-state-unknown    { border-left-color: var(--je-text-dim); }
+.je-optional-plugin-card.je-state-warn       { border-left-color: #ff9800; }
+.je-optional-plugin-icon {
+    font-size: 20px !important;
+    flex-shrink: 0;
     margin-top: 2px;
-    font-weight: normal;
+    color: var(--je-text-muted);
+}
+.je-optional-plugin-card.je-state-installed .je-optional-plugin-icon { color: #4caf50; }
+.je-optional-plugin-card.je-state-warn      .je-optional-plugin-icon { color: #ff9800; }
+.je-optional-plugin-body {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.je-optional-plugin-name {
+    font-weight: 600;
+    font-size: 0.92em;
+}
+.je-optional-plugin-status {
+    font-size: 0.8em;
+    color: var(--je-text-muted);
+    line-height: 1.35;
+}
+.je-optional-plugin-purpose {
+    font-size: 0.78em;
+    color: var(--je-text-subtle);
+    line-height: 1.4;
+    margin-top: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+   Overview Tab — Features dashboard
+   --------------------------------------------------------------------------- */
+.je-features-dashboard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 8px;
+}
+.je-feature-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    background: var(--je-surface-1);
+    border: 1px solid var(--je-border);
+    border-left-width: 3px;
+    border-radius: 8px;
+    cursor: pointer;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    transition: background 0.15s ease, transform 0.15s ease;
+}
+.je-feature-row:hover {
+    background: var(--je-surface-2);
+    transform: translateY(-1px);
+}
+.je-feature-row.je-state-on         { border-left-color: #4caf50; }
+.je-feature-row.je-state-warn       { border-left-color: #ff9800; }
+.je-feature-row.je-state-off        { border-left-color: var(--je-border-strong); opacity: 0.55; }
+.je-feature-icon {
+    font-size: 18px !important;
+    color: var(--je-text-muted);
+    flex-shrink: 0;
+}
+.je-feature-row.je-state-on   .je-feature-icon { color: #4caf50; }
+.je-feature-row.je-state-warn .je-feature-icon { color: #ff9800; }
+.je-feature-body {
+    min-width: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+.je-feature-name {
+    font-size: 0.9em;
+    font-weight: 500;
+}
+.je-feature-detail {
+    font-size: 0.78em;
+    color: var(--je-text-muted);
+    line-height: 1.3;
+    word-break: break-word;
+}
+
+@media (max-width: 540px) {
+    .je-optional-plugins-dashboard,
+    .je-features-dashboard { grid-template-columns: 1fr; }
+    .je-optional-plugin-card, .je-feature-row { padding: 10px; }
+}
+
+/* ---------------------------------------------------------------------------
+   Tab Navigation (sits inside .je-sticky-header which handles pinning)
+   --------------------------------------------------------------------------- */
+.je-tab-bar {
+    display: flex;
+    gap: 10px;
+    padding: 12px 0;
+    margin: 0;
+    border-bottom: 1px solid var(--je-border);
+    overflow-x: auto;
+    scrollbar-width: none;
+    cursor: grab;
+    user-select: none;
+}
+.je-tab-bar::-webkit-scrollbar { display: none; }
+.je-tab-bar.je-dragging {
+    cursor: grabbing;
+    scroll-behavior: auto;
+}
+.je-tab-bar.je-dragging .jellyfin-tab-button {
+    pointer-events: none;
+}
+
+.jellyfin-tab-button {
+    background: var(--je-surface-2);
+    border: 1px solid var(--je-border);
+    border-radius: 30px;
+    padding: 10px 20px;
+    color: #ccc;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.9em;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+.jellyfin-tab-button h3 {
+    margin: 0;
+    font-size: 1em;
+    font-weight: inherit;
+    pointer-events: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.jellyfin-tab-button img,
+.jellyfin-tab-button .je-tab-icon-img {
+    width: 18px;
+    height: 18px;
+    pointer-events: none;
+}
+.jellyfin-tab-button .je-tab-icon {
+    font-size: 20px !important;
+    line-height: 1;
+    opacity: 0.85;
+    pointer-events: none;
+}
+.jellyfin-tab-button.active .je-tab-icon { opacity: 1; }
+.jellyfin-tab-button:hover { background: var(--je-surface-3); }
+.jellyfin-tab-button.active {
+    background: var(--primary-accent-color, #00a4dc);
+    border-color: var(--primary-accent-color, #00a4dc);
+    color: #fff !important;
+    box-shadow: 0 4px 12px color-mix(in srgb, var(--primary-accent-color, #00a4dc) 30%, transparent);
+}
+
+.jellyfin-tab-content {
+    display: none;
+    animation: slideUpFade 0.3s ease forwards;
+}
+.jellyfin-tab-content.active {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
+    gap: 20px;
+    align-items: start;
+}
+
+/* ---------------------------------------------------------------------------
+   Fieldsets (Cards)
+   --------------------------------------------------------------------------- */
+#JellyfinEnhancedForm fieldset {
+    background: rgba(22, 22, 22, 0.94);
+    border: 1px solid var(--je-border);
+    border-radius: 12px;
+    padding: 0;
+    margin: 0;
+    box-shadow: 0 6px 22px rgba(0, 0, 0, 0.22);
+    overflow: hidden;
+    transition: border-color 0.2s ease, box-shadow 0.25s ease;
+}
+#JellyfinEnhancedForm fieldset:hover {
+    border-color: var(--je-border);
+}
+/* Native <legend> has peculiar layout — it's positioned relative to the
+   fieldset's top border and doesn't always respect width/display. The
+   `float: left; width: 100%;` trick normalizes it into a proper block
+   header that spans the full fieldset width. configSection then
+   `clear: both;` so its flow starts below the floated legend. */
+#JellyfinEnhancedForm legend.sectionTitle {
+    float: left;
+    width: 100%;
+    margin: 0;
+    padding: 14px 22px;
+    background: var(--je-legend-gradient);
+    font-size: 1.05em;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    border-bottom: 1px solid var(--je-border);
+    box-sizing: border-box;
+    color: #f5f5f5;
+}
+/* Keep the icon inline with the title on a row, now that the legend
+   is a floated block (display:flex would override the float). */
+#JellyfinEnhancedForm legend.sectionTitle .je-legend-icon {
+    display: inline-block;
+    margin-right: 8px;
+    vertical-align: -4px;
+}
+.configSection {
+    clear: both;
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+/* Let specific fieldsets span full width */
+.jellyfin-tab-content.active > fieldset.je-fieldset-wide,
+.jellyfin-tab-content.active > fieldset.je-overview-section,
+.jellyfin-tab-content.active > fieldset:has(.je-branding-grid),
+.jellyfin-tab-content.active > fieldset:has(.arr-instances-list),
+.jellyfin-tab-content.active > fieldset:has(.je-textarea-large),
+.jellyfin-tab-content.active > fieldset:has(.je-seerr-label) {
+    grid-column: 1 / -1;
+}
+.jellyfin-tab-content.active > .je-info-banner,
+.jellyfin-tab-content.active > .je-dep-banner {
+    grid-column: 1 / -1;
+}
+
+/* ---------------------------------------------------------------------------
+   Inputs, Checkboxes & Form Elements
+   --------------------------------------------------------------------------- */
+.configSection > .inputContainer,
+.configSection > .selectContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.configSection > .inputContainer,
+.configSection > .checkboxContainer,
+.configSection > .selectContainer {
+    background: var(--je-surface-1);
+    border: 1px solid var(--je-border);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 5px !important;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+.configSection > .inputContainer:hover,
+.configSection > .checkboxContainer:hover,
+.configSection > .selectContainer:hover {
+    border-color: var(--je-border);
+    background: var(--je-surface-1);
+}
+.configSection > .inputContainer:focus-within,
+.configSection > .checkboxContainer:focus-within,
+.configSection > .selectContainer:focus-within {
+    border-color: var(--primary-accent-color, #00a4dc);
+    background: var(--je-surface-2);
+    box-shadow: 0 0 0 1px var(--primary-accent-color, #00a4dc) inset;
+}
+
+/* Ensure inputs span fully where intended */
+.configSection > .inputContainer .emby-input,
+.configSection > .inputContainer .emby-select,
+.configSection > .inputContainer .emby-textarea,
+.configSection > .selectContainer .emby-select {
+    width: 100%;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+/* Consistent dropdown chevron across every <select> inside this config page.
+   Jellyfin admin's native emby-select styling sometimes shows no arrow
+   (depending on theme), which makes the control look like a text input. We
+   zero the native appearance and paint our own chevron SVG to guarantee a
+   visible "this is a dropdown" affordance that matches the accent color on
+   focus. */
+#JellyfinEnhancedPage select.emby-select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path fill='none' stroke='%23e0e0e0' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round' d='M1.5 1.5 L6 6 L10.5 1.5'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 14px center;
+    background-size: 12px 8px;
+    padding-right: 36px !important;
+    cursor: pointer;
+}
+#JellyfinEnhancedPage select.emby-select:focus,
+#JellyfinEnhancedPage select.emby-select:focus-visible {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path fill='none' stroke='%2300a4dc' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round' d='M1.5 1.5 L6 6 L10.5 1.5'/></svg>");
+}
+/* IE/Edge legacy — hide the built-in dropdown arrow to avoid double chevrons */
+#JellyfinEnhancedPage select.emby-select::-ms-expand { display: none; }
+
+.checkboxContainer {
+    display: flex;
+    align-items: center;
+}
+.checkboxContainer label {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    cursor: pointer;
+    word-break: break-word;
+}
+.checkboxContainer input[type="checkbox"] {
+    flex-shrink: 0;
+    margin: 0;
+}
+/* Slightly brighter, medium-weight labels — when descriptions are off
+   the label is the only cue, so make it readable first. */
+.checkboxContainer label > span {
+    font-size: 0.95em;
+    font-weight: 500;
+    color: #e8e8e8;
+    line-height: 1.35;
+}
+.inputContainer > label.inputLabel,
+.selectContainer > label.selectLabel,
+.inputContainer > label.selectLabel,
+.selectContainer > label.inputLabel {
+    font-weight: 500;
+    color: #d0d0d0;
+    font-size: 0.9em;
+}
+
+/* Feature-enabler (master-toggle) checkboxes — visually pronounced so
+   the sub-options that follow read as OPTIONS of that feature, not
+   independent peers. Uses :has() to target specific known master IDs;
+   modern browsers (Chrome 105+, Safari 15.4+, Firefox 121+) support
+   it, older fallback is the plain checkbox look (still functional). */
+.configSection > .checkboxContainer:has(> label > input#downloadsPageEnabled),
+.configSection > .checkboxContainer:has(> label > input#calendarPageEnabled),
+.configSection > .checkboxContainer:has(> label > input#bookmarksEnabled),
+.configSection > .checkboxContainer:has(> label > input#hiddenContentEnabled),
+.configSection > .checkboxContainer:has(> label > input#jellyseerrEnabled),
+.configSection > .checkboxContainer:has(> label > input#elsewhereEnabled),
+.configSection > .checkboxContainer:has(> label > input#randomButtonEnabled),
+.configSection > .checkboxContainer:has(> label > input#arrLinksEnabled),
+.configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled),
+.configSection > .checkboxContainer:has(> label > input#activeStreamsEnabled),
+.configSection > .checkboxContainer:has(> label > input#showUserReviews),
+.configSection > .checkboxContainer:has(> label > input#autoSeasonRequestEnabled),
+.configSection > .checkboxContainer:has(> label > input#autoMovieRequestEnabled),
+.configSection > .checkboxContainer:has(> label > input#qualityTagsEnabled),
+.configSection > .checkboxContainer:has(> label > input#tagCacheServerMode) {
+    background: linear-gradient(90deg,
+        color-mix(in srgb, var(--primary-accent-color, #00a4dc) 14%, transparent) 0%,
+        color-mix(in srgb, var(--primary-accent-color, #00a4dc) 2%, transparent) 100%);
+    border-color: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 22%, transparent);
+    border-left: 3px solid var(--primary-accent-color, #00a4dc);
+}
+.configSection > .checkboxContainer:has(> label > input#downloadsPageEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#calendarPageEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#bookmarksEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#hiddenContentEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#jellyseerrEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#elsewhereEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#randomButtonEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#arrLinksEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#activeStreamsEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#showUserReviews) label > span,
+.configSection > .checkboxContainer:has(> label > input#autoSeasonRequestEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#autoMovieRequestEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#qualityTagsEnabled) label > span,
+.configSection > .checkboxContainer:has(> label > input#tagCacheServerMode) label > span {
+    font-weight: 600;
+    font-size: 1.02em;
+    color: #fff;
+    letter-spacing: 0.1px;
+}
+
+/* Integration-choice toggles (Plugin Pages vs Custom Tabs) — pair of
+   alternatives that answer "how do you want this feature delivered?".
+   Subtle purple/blue accent to distinguish from the feature-master. */
+.configSection > .checkboxContainer:has(> label > input[id$="UsePluginPages"]),
+.configSection > .checkboxContainer:has(> label > input[id$="UseCustomTabs"]) {
+    background: rgba(155, 89, 182, 0.05);
+    border-left: 2px solid rgba(155, 89, 182, 0.4);
+}
+
+/* Small visual breather between a master-enabler and its options, so
+   the grouping reads at a glance. */
+.configSection > .checkboxContainer:has(> label > input#downloadsPageEnabled),
+.configSection > .checkboxContainer:has(> label > input#calendarPageEnabled),
+.configSection > .checkboxContainer:has(> label > input#bookmarksEnabled),
+.configSection > .checkboxContainer:has(> label > input#hiddenContentEnabled),
+.configSection > .checkboxContainer:has(> label > input#jellyseerrEnabled),
+.configSection > .checkboxContainer:has(> label > input#elsewhereEnabled),
+.configSection > .checkboxContainer:has(> label > input#randomButtonEnabled),
+.configSection > .checkboxContainer:has(> label > input#arrLinksEnabled),
+.configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled),
+.configSection > .checkboxContainer:has(> label > input#showUserReviews) {
+    margin-bottom: 12px !important;
+}
+
+.fieldDescription {
+    color: #aaa;
+    font-size: 0.85em;
+    margin-top: 8px;
+    line-height: 1.4;
+}
+
+/* Beautiful grouping of descriptions without negative margins */
+.je-setting-description {
+    margin-top: 4px;
+    margin-bottom: 12px;
+    padding-left: 14px;
+    border-left: 2px solid var(--je-border);
+}
+.checkboxContainer + .fieldDescription,
+.inputContainer + .fieldDescription,
+.selectContainer + .fieldDescription {
+    margin-top: 4px;
+    margin-bottom: 12px;
+    padding-left: 14px;
+    border-left: 2px solid var(--je-border);
+}
+/* Inside flex containers (.configSection, .je-details-body) the parent's `gap`
+   already provides between-child spacing. The 4px + 12px margins above DON'T
+   collapse against the gap — they stack with it, adding ~16px of extra space
+   between each setting. Zero them out so the gap alone owns the spacing. */
+.configSection > .je-setting-description,
+.je-details-body > .je-setting-description {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+/* Inner .fieldDescription adds margin-top: 8px globally (see :645) for the
+   stand-alone case where it follows a checkbox directly. Inside a
+   .je-setting-description wrapper the wrapper already provides the visual
+   indent + spacing, so the inner margin would just push text further from
+   its border + add a visible gap. Zero it here. */
+.je-setting-description > .fieldDescription {
+    margin-top: 0;
+}
+/* Tighten the gap inside accordion bodies — 15px reads as too loose for
+   a stack of toggle+description pairs since the description block already
+   has its border + padding making it visually distinct. */
+.je-details-body { gap: 10px; }
+
+/* ---------------------------------------------------------------------------
+   Accordions (Details / Summary)
+   --------------------------------------------------------------------------- */
+.je-details-section, .je-seerr-details {
+    background: var(--je-overlay);
+    border: 1px solid var(--je-border-subtle);
+    border-radius: 10px;
+    margin: 5px 0 10px 0;
+    overflow: hidden;
+    transition: background-color 0.25s ease, border-color 0.25s ease;
+}
+.je-details-section:hover, .je-seerr-details:hover {
+    border-color: var(--je-border);
+}
+.je-details-section[open], .je-seerr-details[open] {
+    background: var(--je-surface-1);
+    border-color: var(--je-border);
+}
+.je-details-section > summary, .je-seerr-details > summary {
+    background: transparent;
+    padding: 14px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    list-style: none;
+    user-select: none;
+    color: rgba(240, 240, 240, 0.82);
+    transition: color 0.2s ease;
+}
+.je-details-section[open] > summary,
+.je-seerr-details[open] > summary {
+    color: #f5f5f5;
+}
+.je-details-section > summary:hover,
+.je-seerr-details > summary:hover {
+    color: #fff;
+}
+.je-details-section > summary::-webkit-details-marker,
+.je-seerr-details > summary::-webkit-details-marker {
+    display: none;
+}
+.je-details-section > summary::after,
+.je-seerr-details > summary::after {
+    content: "expand_more";
+    font-family: "Material Icons";
+    font-size: 22px;
+    transition: transform 0.25s ease, color 0.2s ease;
+    color: var(--je-text-subtle);
+    line-height: 1;
+    flex-shrink: 0;
+}
+.je-details-section[open] > summary::after,
+.je-seerr-details[open] > summary::after {
+    transform: rotate(180deg);
+    color: var(--primary-accent-color, #00a4dc);
+}
+.je-details-body {
+    padding: 0 20px 20px 20px;
+    border-top: 1px solid var(--je-border);
+    margin-top: 5px;
+    padding-top: 15px;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
 }
 
 /* ---------------------------------------------------------------------------
    Arr instance cards
    --------------------------------------------------------------------------- */
+/* Instance cards mirror the .je-details-section (Tag Filters) look: subtle
+   on rest, slightly lighter on open, no strong accent border. Keep a
+   chevron summary prefix but mute the color so it feels consistent with
+   other collapsibles on the page. */
 .arr-instance-card {
-    border: 1px solid rgba(255,255,255,0.1);
-    border-radius: 8px;
-    margin-bottom: 1em;
-    background: rgba(255,255,255,0.03);
+    background: var(--je-overlay);
+    border: 1px solid var(--je-border-subtle);
+    border-radius: 10px;
+    margin: 5px 0 10px 0;
+    overflow: hidden;
+    transition: background-color 0.25s ease, border-color 0.25s ease;
+}
+.arr-instance-card:hover  { border-color: var(--je-border); }
+.arr-instance-card[open] {
+    background: var(--je-surface-1);
+    border-color: var(--je-border);
 }
 .arr-instance-card > summary {
     display: flex;
     align-items: center;
-    gap: 0.5em;
-    padding: 0.8em 1em;
+    gap: 12px;
+    padding: 14px 18px;
     cursor: pointer;
     list-style: none;
     user-select: none;
+    background: transparent;
+    color: rgba(240, 240, 240, 0.82);
 }
 .arr-instance-card > summary::-webkit-details-marker { display: none; }
 .arr-instance-card > summary::before {
-    content: "\25B6";
-    font-size: 0.7em;
+    content: "\e5cc";
+    font-family: "Material Icons";
+    font-size: 20px;
     transition: transform 0.2s;
-    color: rgba(255,255,255,0.5);
+    color: var(--je-text-subtle);
 }
 .arr-instance-card[open] > summary::before {
     transform: rotate(90deg);
+    color: var(--je-text-strong);
 }
-.arr-instance-card > summary .arr-instance-summary-name {
-    flex: 1;
-    font-weight: 500;
+
+/* Custom toggle for the per-instance Enabled checkbox (can't use is="emby-checkbox"
+   because the summary row has no <label><span> wrapper). Renders as a
+   pill-style switch that inherits the accent color when checked. */
+.arr-instance-enabled {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 34px;
+    height: 18px;
+    border-radius: 999px;
+    background: var(--je-surface-3);
+    border: 1px solid var(--je-border-strong);
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    transition: background 0.18s ease, border-color 0.18s ease;
+    margin: 0;
 }
-.arr-instance-card > summary .arr-instance-summary-url {
-    color: rgba(255,255,255,0.4);
+.arr-instance-enabled::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 2px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #ddd;
+    transform: translateY(-50%);
+    transition: left 0.18s ease, background 0.18s ease;
+}
+.arr-instance-enabled:hover {
+    border-color: var(--je-text-dim);
+}
+.arr-instance-enabled:checked {
+    background: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 70%, transparent);
+    border-color: var(--primary-accent-color, #00a4dc);
+}
+.arr-instance-enabled:checked::before {
+    left: 18px;
+    background: #fff;
+}
+.arr-instance-enabled:focus-visible {
+    outline: 2px solid var(--primary-accent-color, #00a4dc);
+    outline-offset: 2px;
+}
+.arr-instance-summary-name { flex: 1; font-weight: 600; }
+.arr-instance-summary-url {
+    color: var(--je-text-subtle);
     font-size: 0.85em;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 300px;
+    max-width: 250px;
 }
 .arr-instance-card-body {
-    padding: 0 1em 1em;
+    padding: 15px 18px;
+    border-top: 1px solid var(--je-border);
 }
-.arr-instance-card-body .arr-instance-header {
+.arr-instance-header {
     display: flex;
     align-items: center;
-    gap: 0.5em;
-    margin-bottom: 0.5em;
+    gap: 10px;
+    margin-bottom: 10px;
 }
-.arr-instance-card-body .arr-instance-header input {
-    flex: 1;
-}
-.arr-instance-card > summary .arr-instance-enabled {
-    flex: 0 0 auto;
-    cursor: pointer;
-    margin: 0 0.25em 0 0;
-    width: 1.15em;
-    height: 1.15em;
-}
-.arr-instance-card.arr-instance-disabled {
-    opacity: 0.6;
-}
-.arr-instance-card.arr-instance-disabled > summary .arr-instance-enabled {
-    /* Checkbox stays full-opacity so the admin can see + click to re-enable
-       even when the rest of the card is dimmed. */
-    opacity: 1;
-}
-.arr-instance-card.arr-instance-disabled > summary .arr-instance-summary-name {
+.arr-instance-disabled { opacity: 0.6; }
+.arr-instance-disabled > summary .arr-instance-enabled { opacity: 1; }
+.arr-instance-disabled > summary .arr-instance-summary-name {
     text-decoration: line-through;
-    color: rgba(255,255,255,0.55);
+    color: var(--je-text-muted);
 }
 .arr-instance-remove {
     background: transparent;
-    border: 1px solid rgba(255,80,80,0.5);
-    color: #ff5050;
-    border-radius: 4px;
-    padding: 0.3em 0.6em;
+    border: 1px solid rgba(220,53,69,0.5);
+    color: #ff6b6b;
+    border-radius: 6px;
+    padding: 6px 12px;
     cursor: pointer;
     font-size: 0.85em;
+    transition: all 0.2s;
 }
 .arr-instance-remove:hover {
-    background: rgba(255,80,80,0.15);
-}
-.arr-add-btn {
-    margin-top: 0.5em;
-    margin-bottom: 1em;
-}
-
-/* ---------------------------------------------------------------------------
-   Arr corrupt-config banner
-   --------------------------------------------------------------------------- */
-.arr-corrupt-banner {
-    padding: 0.8em 1em;
-    margin-bottom: 1em;
-    border: 1px solid #dc3545;
     background: rgba(220,53,69,0.15);
-    border-radius: 4px;
+    color: #ff4c4c;
 }
 
 /* ---------------------------------------------------------------------------
-   Arr mappings validation result box
+   Sticky Save Dock
    --------------------------------------------------------------------------- */
-#arrMappingsValidationResult {
-    display: none;
-    margin-top: 0.8em;
-    padding: 0.8em 1em;
-    border-radius: 4px;
-    font-size: 0.9em;
-    line-height: 1.5;
-}
-
-/* ---------------------------------------------------------------------------
-   Section title header row
-   --------------------------------------------------------------------------- */
-.sectionTitleContainer {
+.je-save-dock {
+    position: fixed;
+    bottom: 30px;
+    left: 50%;
+    transform: translateX(-50%);
     display: flex;
+    justify-content: center;
     align-items: center;
-    flex-wrap: wrap;
-    gap: 0.5em;
+    background: rgba(25, 25, 25, 0.9);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--je-border);
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
+    border-radius: 50px;
+    padding: 10px 16px;
+    z-index: 2000;
+}
+.je-save-dock .je-save-dock-btn {
+    margin: 0 !important;
+    border-radius: 50px !important;
+    padding: 10px 28px !important;
+    font-weight: 600;
+    font-size: 1em;
+    letter-spacing: 0.5px;
+    background: var(--primary-accent-color, #00a4dc);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+.je-save-dock .je-save-dock-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 15px rgba(0,0,0,0.3);
+}
+.je-save-dock-icon {
+    font-size: 20px !important;
+    line-height: 1;
 }
 
 /* ---------------------------------------------------------------------------
-   Page-level color
+   Banners & Alerts
    --------------------------------------------------------------------------- */
-#JellyfinEnhancedPage {
-    color: #eee;
-}
-
-/* ---------------------------------------------------------------------------
-   Help link button in header
-   --------------------------------------------------------------------------- */
-.je-help-link {
-    margin-left: 2em;
-}
-
-/* ---------------------------------------------------------------------------
-   Tab bar wrapper
-   --------------------------------------------------------------------------- */
-.je-tab-bar {
-    margin-bottom: 1em;
-}
-
-/* (duplicate #settingsSearchContainer > div already declared above) */
-.je-search-icon {
-    position: absolute;
-    left: 0.6em;
-    top: 50%;
-    transform: translateY(-50%);
-    color: rgba(255,255,255,0.4);
-    pointer-events: none;
-    font-size: 1.1em;
-}
-
-/* ---------------------------------------------------------------------------
-   File Transformation warning banner  (#fileTransformationWarning is shown/hidden by JS)
-   --------------------------------------------------------------------------- */
-#fileTransformationWarning {
-    margin-bottom: 1em;
-    padding: 1em 1.2em;
-    background-color: rgba(255, 165, 0, 0.15);
-    border: 1px solid rgba(255, 165, 0, 0.5);
+.je-info-banner, .je-info-banner-inline, .je-info-banner-inline-center, .je-info-banner-compact,
+.je-note-banner, .je-danger-banner, .je-purple-banner, .je-mobile-banner, .je-splash-info-banner, .je-dep-banner {
     border-radius: 8px;
-    color: #ffcc00;
-    font-size: 0.95em;
-    line-height: 1.5;
-    position: relative;
-}
-.je-ft-warning-title {
-    font-size: 1.05em;
-}
-.je-ft-warning-link {
-    color: #ffa500;
-    text-decoration: underline;
-}
-.je-ft-warning-code {
-    background: rgba(255,255,255,0.1);
-    padding: 2px 5px;
-    border-radius: 3px;
-}
-.je-ft-warning-actions {
-    margin-top: 0.8em;
     display: flex;
-    gap: 0.6em;
-}
-.je-ft-warning-btn {
-    background: rgba(255,255,255,0.1);
-    border: 1px solid rgba(255,165,0,0.4);
-    color: #ffcc00;
-    padding: 4px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.85em;
-}
-
-/* ---------------------------------------------------------------------------
-   Collapsible details sections  (used throughout all tabs)
-   --------------------------------------------------------------------------- */
-.je-details-section {
-    margin-bottom: 1em;
-    background-color: rgba(255,255,255,0.05);
-    padding: 1em;
-    border-radius: 5px;
-}
-.je-details-section > summary {
-    cursor: pointer;
-    font-weight: bold;
-}
-.je-details-body {
-    padding-top: 1em;
-}
-
-/* ---------------------------------------------------------------------------
-   Checkbox containers — standard bottom margin
-   --------------------------------------------------------------------------- */
-.checkboxContainer {
-    margin-bottom: 0.5em;
-}
-
-/* ---------------------------------------------------------------------------
-   fieldDescription spacing variants
-   Use je-field-desc-sm/md/lg/xl for bottom-margin only.
-   Add je-field-desc-small-text for the 0.8em font-size variant.
-   --------------------------------------------------------------------------- */
-.je-field-desc-sm  { margin-bottom: 0.5em; }
-.je-field-desc-md  { margin-bottom: 1em; }
-.je-field-desc-lg  { margin-bottom: 1.5em; }
-.je-field-desc-xl  { margin-bottom: 2em; }
-
-/* Small font (0.8em) — combine with a spacing class as needed */
-/* .je-field-desc-small-text available if needed: font-size: 0.8em */
-
-/* Convenience combos used in the HTML */
-.je-field-desc-sm-font-lg  { margin-bottom: 1.5em; font-size: 0.8em; }
-.je-field-desc-sm-font-xl  { margin-bottom: 2em;   font-size: 0.8em; }
-
-/* Top-margin only variant */
-.je-field-desc-mt    { margin-top: 1em; }
-.je-field-desc-mt-sm { margin-top: 0.5em; }
-
-/* ---------------------------------------------------------------------------
-   Spacing utilities — margin-top / margin-bottom helpers
-   --------------------------------------------------------------------------- */
-/* Top margin */
-.je-mt-sm  { margin-top: 0.5em; }
-.je-mt-md  { margin-top: 1em; }
-.je-mt-lg  { margin-top: 1.5em; }
-.je-mt-xl  { margin-top: 2em; }
-
-/* Bottom margin */
-.je-mb-sm  { margin-bottom: 0.5em; }
-.je-mb-md  { margin-bottom: 1em; }
-.je-mb-lg  { margin-bottom: 1.5em; }
-.je-mb-xl  { margin-bottom: 2em; }
-
-/* Legacy aliases kept for HTML compatibility */
-.je-input-mt       { margin-top: 1em; }
-.je-input-mb       { margin-bottom: 1em; }
-.je-input-mb-sm    { margin-bottom: 0.5em; }
-.je-checkbox-mt    { margin-top: 1em; }
-.je-checkbox-mt-2  { margin-top: 2em; margin-bottom: 0.5em; }
-.je-checkbox-mb-1  { margin-bottom: 1em; }
-.je-checkbox-mb-2  { margin-bottom: 2em; }
-.je-checkbox-mb-075 { margin-bottom: 0.75em; }
-.je-checkbox-mb-15 { margin-bottom: 1.5em; }
-.je-select-mb      { margin-bottom: 1.5em; }
-.je-apply-section  { margin-top: 2em; }
-.je-label-mb       { margin-bottom: 2em; }
-
-/* ---------------------------------------------------------------------------
-   Tags sub-fieldset
-   --------------------------------------------------------------------------- */
-.je-tags-fieldset {
-    margin-top: 1em;
-    padding: 2em;
-    border-radius: 20px;
-    border-color: #ffffff25;
-}
-
-
-.je-rating-label {
-    line-height: 1.2em;
-    align-self: flex-start;
-}
-
-/* ---------------------------------------------------------------------------
-   Divider sections — shared border pattern
-   --------------------------------------------------------------------------- */
-/* Bottom-border dividers */
-.je-icon-section,
-.je-section-panel {
-    margin-bottom: 2em;
-    padding-bottom: 1.5em;
-    border-bottom: 1px solid rgba(255,255,255,0.1);
-}
-/* Top-border dividers */
-.je-extras-divider,
-.je-custom-links-section {
-    margin-top: 2em;
-    padding-top: 1.5em;
-    border-top: 1px solid rgba(255,255,255,0.1);
-}
-
-/* ---------------------------------------------------------------------------
-   Shortcuts section
-   --------------------------------------------------------------------------- */
-.je-section-h4 { margin-top: 0; }
-.je-shortcut-add-row {
-    display: flex;
-    gap: 1em;
-    align-items: flex-end;
-}
-.je-shortcut-add-row > div { flex: 1; }
-.je-shortcut-add-btn {
-    top: 10px;
-}
-#shortcut-error-comment {
-    color: #ffdddd;
-    font-size: 0.9em;
-    margin-top: 0.75em;
-    background-color: rgba(220, 53, 69, 0.2);
-    padding: 0.5em;
-    border-radius: 4px;
-    border-left: 3px solid #dc3545;
-}
-.je-shortcut-list {
-    display: flex;
-    flex-direction: column;
-    margin-top: 1em;
-}
-.je-field-desc-mt {
-    margin-top: 1em;
-}
-
-/* ---------------------------------------------------------------------------
-   Info / note / warning banners
-   All banners share a base shape. Color and spacing vary per modifier.
-   --------------------------------------------------------------------------- */
-
-/* Shared base */
-.je-info-banner,
-.je-info-banner-inline,
-.je-info-banner-inline-center,
-.je-info-banner-compact,
-.je-note-banner,
-.je-danger-banner,
-.je-purple-banner,
-.je-mobile-banner,
-.je-splash-info-banner {
+    gap: 15px;
+    padding: 14px 20px;
+    margin: 10px 0;
+    align-items: center;
     border-left-width: 4px;
     border-left-style: solid;
-    border-radius: 4px;
-    display: flex;
-    gap: 1em;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
+.je-info-banner-row { display: flex; align-items: flex-start; gap: 15px; }
 
-/* Blue — info */
-.je-info-banner,
-.je-info-banner-inline,
-.je-info-banner-inline-center,
-.je-info-banner-compact,
-.je-splash-info-banner {
-    background-color: rgba(255,255,255,0.05);
-    border-left-color: #00a4dc;
+.je-info-banner, .je-info-banner-inline, .je-info-banner-inline-center, .je-info-banner-compact, .je-splash-info-banner {
+    background-color: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 10%, transparent);
+    border-left-color: var(--primary-accent-color, #00a4dc);
 }
-/* The non-inline variant has a slightly stronger tint */
-.je-info-banner {
-    background-color: rgba(0,164,220,0.1);
+.je-note-banner, .je-mobile-banner, .je-dep-banner {
+    background-color: rgba(255,193,7,0.1); border-left-color: #ffc107;
 }
-
-/* Yellow — note / mobile */
-.je-note-banner,
-.je-mobile-banner {
-    background-color: rgba(255,193,7,0.1);
-    border-left-color: #ffc107;
-}
-
-/* Red — danger */
 .je-danger-banner {
-    background-color: rgba(220,53,69,0.1);
-    border-left-color: #dc3545;
+    background-color: rgba(220,53,69,0.15); border-left-color: #ff6b6b;
 }
-
-/* Purple — Seerr affiliation */
 .je-purple-banner {
-    background-color: rgba(100,50,150,0.08);
-    border-left-color: #9b59b6;
+    background-color: rgba(155,89,182,0.15); border-left-color: #9b59b6;
 }
 
-/* Padding variants */
-.je-info-banner,
-.je-info-banner-inline,
-.je-info-banner-inline-center,
-.je-purple-banner,
-.je-mobile-banner {
-    padding: 1em 1.5em;
-}
-.je-info-banner-compact,
-.je-note-banner,
-.je-danger-banner,
-.je-splash-info-banner {
-    padding: 0.5em 1em;
-}
-
-/* Margin variants */
-.je-info-banner                { margin-top: 1em; }
-.je-info-banner-inline,
-.je-info-banner-inline-center,
-.je-purple-banner              { margin: 1.5em 0; }
-.je-mobile-banner              { margin: 1em 0; }
-.je-info-banner-compact,
-.je-note-banner,
-.je-danger-banner              { margin: 0 0 1.5em 0; }
-.je-splash-info-banner         { margin: 2em 0 0.5em 0; }
-
-/* Alignment variants */
-.je-info-banner-inline,
-.je-mobile-banner              { align-items: flex-start; }
-.je-info-banner-inline-center,
-.je-info-banner-compact,
-.je-note-banner,
-.je-danger-banner,
-.je-purple-banner,
-.je-splash-info-banner         { align-items: center; }
-
-/* Row inside non-flex banners */
-.je-info-banner-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 1em;
-}
-
-/* Icons */
-.je-info-icon,
-.je-bottom-info-icon {
-    color: #00a4dc;
-    font-size: 24px;
-    margin-top: 2px;
-    flex-shrink: 0;
-}
-.je-info-icon-sm {
-    color: #00a4dc;
-    font-size: 18px;
-    margin-top: 2px;
-    flex-shrink: 0;
-}
-.je-note-icon,
-.je-mobile-icon {
-    color: #ffc107;
-    font-size: 18px;
-    flex-shrink: 0;
-}
-.je-mobile-icon { margin-top: 2px; }
-.je-danger-icon {
-    color: #dc3545;
-    font-size: 18px;
-    flex-shrink: 0;
-}
-.je-purple-icon {
-    color: #9b59b6;
-    font-size: 18px;
-    flex-shrink: 0;
-}
+.je-info-icon, .je-bottom-info-icon, .je-info-icon-sm { color: var(--primary-accent-color, #00a4dc); font-size: 24px; flex-shrink: 0; margin-top: 2px; }
+.je-note-icon, .je-mobile-icon, .je-dep-banner-icon { color: #ffc107; font-size: 24px; flex-shrink: 0; margin-top: 2px; }
+.je-danger-icon { color: #ff6b6b; font-size: 24px; flex-shrink: 0; margin-top: 2px; }
+.je-purple-icon { color: #9b59b6; font-size: 24px; flex-shrink: 0; margin-top: 2px; }
+.je-hidden { display: none !important; }
 
 /* ---------------------------------------------------------------------------
-   Elsewhere tab
+   Search Highlight Utilities
    --------------------------------------------------------------------------- */
-.je-elsewhere-checkbox {
-    margin-bottom: 2em;
+.je-search-hidden { display: none !important; }
+.je-search-match {
+    background-color: rgba(255,200,0,0.35);
+    color: #fff;
+    border-radius: 4px;
+    padding: 0 3px;
+    box-shadow: 0 0 0 1px rgba(255,200,0,0.25);
 }
-.je-elsewhere-label {
-    line-height: 1.2em;
-    align-self: flex-start;
-}
-.je-api-row {
-    display: flex;
-    align-items: center;
-    gap: 1em;
-    margin-left: -1em;
-}
-.je-api-input {
-    flex-grow: 1;
-}
-.je-status-indicator {
-    transition: color 0.3s ease;
-}
-.je-textarea-tall   { display: block; height: 10vh !important; }
-.je-textarea-medium { display: block; height: 8vh !important; }
-.je-textarea-large  { display: block; height: 12vh !important; }
-.je-h3-mt    { margin-top: 1em; }
-.je-h3-mt-lg { margin-top: 2.5em; }
-
-/* ---------------------------------------------------------------------------
-   Jellyseerr tab
-   --------------------------------------------------------------------------- */
-.je-seerr-label { margin-bottom: 5px; }
-
-/* je-seerr-details shares the same shape as je-details-section */
-.je-seerr-details {
-    margin: 2em 0;
-    background-color: rgba(255,255,255,0.05);
-    padding: 1em;
-    border-radius: 5px;
-}
-.je-seerr-details > summary {
-    cursor: pointer;
+.je-search-match-active {
+    background-color: rgba(255,165,0,0.85);
+    box-shadow: 0 0 0 2px rgba(255,165,0,0.5);
+    color: #000;
     font-weight: bold;
 }
-.je-validation-result { margin-top: 0.8em; }
-/* je-input-mb is defined in spacing utilities above */
-
-/* ---------------------------------------------------------------------------
-   Auto movie request — custom settings panel
-   --------------------------------------------------------------------------- */
-#autoMovieRequestCustomSettings {
-    margin-bottom: 1.5em;
-    padding: 1em;
-    background-color: rgba(255,255,255,0.03);
-    border-radius: 4px;
-    border: 1px solid rgba(255,255,255,0.1);
-}
-.je-custom-settings-row {
+.je-search-tab-label {
+    font-size: 1.4em;
+    font-weight: 700;
+    color: var(--primary-accent-color, #00a4dc);
     margin-bottom: 1em;
-}
-/* je-custom-settings-label and je-trigger-label are identical */
-.je-custom-settings-label,
-.je-trigger-label {
-    display: block;
-    margin-bottom: 0.5em;
-    font-weight: 500;
-}
-.je-trigger-section {
-    margin-bottom: 1.5em;
-}
-.je-quality-mode-section {
-    margin-bottom: 1.5em;
-    margin-top: 1.5em;
-}
-.je-minutes-input {
-    width: 100px;
-    padding: 0.5em;
-    border: 1px solid #555;
-    border-radius: 4px;
-}
-.je-minutes-label { margin-left: 0.5em; }
-
-/* ---------------------------------------------------------------------------
-   Watchlist memory retention
-   --------------------------------------------------------------------------- */
-.je-retention-input {
-    width: 100px;
-}
-.je-retention-list {
-    margin: 0.5em 0;
-    padding-left: 1.5em;
-}
-.je-retention-list li {
-    margin-bottom: 0.3em;
+    padding-bottom: 0.5em;
+    border-bottom: 2px solid var(--je-border);
+    grid-column: 1 / -1;
 }
 
 /* ---------------------------------------------------------------------------
-   Blocked users panel
-   --------------------------------------------------------------------------- */
-#blockedUsersContainer {
-    padding: 0.5em 0;
-    max-height: 300px;
-    overflow-y: auto;
-}
-.je-blocked-user-row {
-    margin-bottom: 0.3em;
-}
-#blockedUsersScrollHint {
-    text-align: center;
-    font-size: 0.75em;
-    opacity: 0.45;
-    margin-top: 0.3em;
-    pointer-events: none;
-}
-.je-import-btn {
-    max-width: 300px;
-}
-
-/* ---------------------------------------------------------------------------
-   *arr tab
-   --------------------------------------------------------------------------- */
-.je-arr-hr {
-    border-color: rgba(255,255,255,0.1);
-    margin: 1.5em 0;
-}
-.je-arr-bazarr-container {
-    margin-top: 1em;
-    margin-bottom: 2em;
-}
-.je-arr-mappings-section {
-    margin-top: 1em;
-}
-.je-arr-mappings-label {
-    margin-bottom: 5px;
-}
-.je-arr-validate-section {
-    margin-top: 1em;
-}
-.je-arr-checkbox-mt {
-    margin-top: 1em;
-    margin-bottom: 0.5em;
-}
-
-/* ---------------------------------------------------------------------------
-   Calendar tab
-   --------------------------------------------------------------------------- */
-.je-calendar-checkbox-mt {
-    margin-top: 1.5em;
-    margin-bottom: 0.5em !important;
-}
-
-/* ---------------------------------------------------------------------------
-   Extras tab — screenshot previews
-   --------------------------------------------------------------------------- */
-.je-screenshot-img {
-    max-width: 400px;
-    margin: 0.5em 0;
-    border-radius: 10px;
-}
-.je-screenshot-img-sm {
-    max-width: 200px;
-    margin: 0.5em 0;
-    border-radius: 10px;
-}
-/* je-extras-divider is defined in the divider sections block above */
-
-/* ---------------------------------------------------------------------------
-   Custom Branding section
+   Custom Branding Dropzones
    --------------------------------------------------------------------------- */
 .je-branding-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5em;
-    margin-bottom: 1.5em;
-    align-items: stretch;
+    gap: 20px;
+    margin: 15px 0;
 }
 .je-branding-card {
+    background: var(--je-overlay-soft);
+    border: 1px solid var(--je-border);
+    border-radius: 12px;
+    padding: 16px;
     display: flex;
     flex-direction: column;
-    gap: 0.5em;
-    height: 100%;
+    gap: 8px;
 }
-.je-branding-label-bold {
-    font-weight: bold;
-    color: #eee;
-}
-.je-branding-label {
-    color: #eee;
-}
-.je-branding-meta {
-    font-size: 0.75em;
-    color: #999;
-    margin-bottom: 0.5em;
-}
+.je-branding-label-bold { font-weight: bold; color: #fff; font-size: 1.05em; }
+.je-branding-label { color: #aaa; font-size: 0.85em; }
+.je-branding-meta { font-size: 0.8em; color: #aaa; margin-bottom: 10px; }
 .je-branding-dropzone {
-    position: relative;
-    background: rgba(255,255,255,0.05);
-    border: 2px dashed rgba(0,164,220,0.5);
-    border-radius: 4px;
-    padding: 0.85em;
+    background: var(--je-surface-1);
+    border: 2px dashed color-mix(in srgb, var(--primary-accent-color, #00a4dc) 50%, transparent);
+    border-radius: 8px;
+    padding: 20px;
     text-align: center;
     cursor: pointer;
-    min-height: 170px;
+    min-height: 180px;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    flex: 1;
+    transition: all 0.2s;
+    position: relative;
 }
-.je-branding-placeholder {
-    margin-bottom: 0.5em;
+.je-branding-dropzone:hover {
+    background: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 5%, transparent);
+    border-color: var(--primary-accent-color, #00a4dc);
 }
-.je-branding-placeholder-icon {
-    font-size: 32px;
-    color: #00a4dc;
-}
-.je-branding-preview {
-    max-height: 80px;
-    border-radius: 4px;
-    display: block;
-    margin: 0 auto .5em auto;
-}
-.je-branding-dimensions {
-    font-size: 0.75em;
-    color: #00a4dc;
-    margin-top: 0.25em;
-}
-.je-branding-hint {
-    font-size: 0.9em;
-    color: #ccc;
-}
-.je-branding-maxsize {
-    font-size: 0.8em;
-    color: #999;
-    margin-top: 0.5em;
-}
-.je-branding-status {
-    font-size: 0.8em;
-    margin-top: 0.5em;
-    color: #999;
-}
-.je-branding-delete {
-    display: none;
+.je-branding-file-input {
     position: absolute;
-    top: 8px;
-    right: 8px;
-    background: rgba(0,0,0,0.4) !important;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+.je-branding-preview { max-height: 100px; border-radius: 4px; margin-bottom: 10px; }
+.je-branding-placeholder { color: var(--je-text-dim); font-size: 2em; }
+.je-branding-placeholder-icon { font-size: 2.5em; }
+.je-branding-status { font-size: 0.85em; margin-top: 5px; min-height: 1em; }
+.je-branding-dimensions { font-size: 0.75em; opacity: 0.5; margin-top: 3px; }
+.je-branding-hint { font-size: 0.85em; opacity: 0.7; margin-top: 5px; }
+.je-branding-maxsize { font-size: 0.7em; opacity: 0.4; margin-top: 2px; }
+.je-branding-delete {
+    position: absolute;
+    top: 10px; right: 10px;
+    background: var(--je-overlay-hard) !important;
     border: none;
     color: #fff !important;
     padding: 6px !important;
-    border-radius: 4px !important;
+    border-radius: 50% !important;
+    width: 36px; height: 36px;
+    display: flex; align-items: center; justify-content: center;
 }
-.je-branding-delete:hover {
-    background: #c62828 !important;
-}
-.je-branding-file-input {
-    display: none;
-}
+.je-branding-delete:hover { background: #e53935 !important; }
+
+/* ---------------------------------------------------------------------------
+   Misc / Utility
+   --------------------------------------------------------------------------- */
+.je-help-link { border-radius: 20px; }
+.je-api-row { display: flex; align-items: center; gap: 12px; width: 100%; }
+.je-api-row .je-api-input { flex-grow: 1; width: auto; margin: 0; }
+.je-textarea-tall { height: 120px !important; }
+.je-textarea-medium { height: 90px !important; }
+.je-textarea-large { height: 160px !important; }
+.je-bold-link { font-weight: bold; color: #fff; text-decoration: underline; }
+.je-kbd { background: var(--je-surface-3); padding: 3px 6px; border-radius: 4px; font-family: monospace; }
+.je-screenshot-img { max-width: 100%; border-radius: 8px; margin-top: 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+.je-screenshot-img-sm { max-width: 60%; }
+.je-loading-text { opacity: 0.5; }
+
 .je-copy-code-wrapper {
     position: relative;
+    margin: 10px 0;
 }
 .je-copy-html-btn {
     position: absolute;
-    top: 8px;
-    right: 8px;
-    background-color: rgba(255,255,255,0.1);
-    border: none;
-    padding: 4px 8px;
-    min-width: 80px;
-    transition: color 0.3s;
-}
-.je-copy-icon {
-    font-size: 16px;
-    margin-right: 4px;
-    vertical-align: middle;
-}
-.je-copy-btn-text {
-    vertical-align: middle;
+    top: 5px;
+    right: 5px;
+    font-size: 0.75em !important;
+    padding: 4px 10px !important;
+    z-index: 2;
 }
 .je-code-pre {
-    background-color: rgba(0,0,0,0.3);
-    padding: 1em;
-    border-radius: 4px;
-    white-space: pre-wrap;
-    word-break: break-all;
+    background: var(--je-overlay-hard);
+    padding: 12px 75px 12px 16px !important; /* Pad right so copy btn doesn't overlap text */
+    border-radius: 6px;
+    overflow-x: auto;
+    font-size: 0.85em;
     margin: 0;
-    font-family: 'Courier New', Courier, monospace;
-}
-.je-custom-tabs-link {
-    text-decoration: underline;
-}
-.je-custom-tabs-ol {
-    margin: 1em 0;
-    padding-left: 1.5em;
-}
-.je-custom-tabs-li {
-    margin-bottom: 0.5em;
-}
-.je-custom-tabs-p {
-    margin: 0 0 0.5em 0;
-}
-.je-custom-tabs-p-mt {
-    margin: 0.5em 0;
-}
-.je-custom-tabs-h4 {
-    margin: 0 0 0.5em 0;
-}
-/* je-custom-tabs-desc-mt removed — not used in HTML */
-
-/* ---------------------------------------------------------------------------
-   Bookmarks / Hidden Content — how-to list
-   --------------------------------------------------------------------------- */
-.je-howto-list {
-    margin: 0.5em 0;
-    padding-left: 1.5em;
-}
-.je-howto-li {
-    margin-bottom: 0.5em;
-}
-.je-kbd {
-    background: rgba(255,255,255,0.1);
-    padding: 2px 6px;
-    border-radius: 3px;
-    font-family: monospace;
-}
-.je-icon-inline {
-    font-size: 16px;
-    vertical-align: middle;
-}
-.je-icon-inline-colored {
-    font-size: 16px;
-    vertical-align: middle;
-    color: #00d4ff;
+    border: 1px solid var(--je-border);
 }
 
-/* ---------------------------------------------------------------------------
-   Splash screen section
-   --------------------------------------------------------------------------- */
-/* je-splash-info-banner is defined in the banners section above */
-
-/* ---------------------------------------------------------------------------
-   Arr instance card — JS-created elements
-   --------------------------------------------------------------------------- */
-.arr-instance-summary-disabled {
-    color: #e5a00d;
-    font-size: 0.85em;
-    margin-right: 0.5em;
-}
-.je-mappings-summary {
-    cursor: pointer;
-    color: rgba(255,255,255,0.6);
-    font-size: 0.9em;
-}
-/* Both containers share the same top margin */
-.je-mappings-details,
-.je-instance-url-container,
-.je-instance-api-container { margin-top: 0.5em; }
-
-.je-instance-api-row {
-    display: flex;
-    align-items: center;
-    gap: 1em;
-}
-/* Both inputs take remaining flex space */
-.je-instance-api-input,
-.je-instance-name-input { flex: 1; }
-
-/* ---------------------------------------------------------------------------
-   Dep banner (created by JS)
-   --------------------------------------------------------------------------- */
-.je-dep-banner {
-    background-color: rgba(255, 165, 0, 0.15);
-    border-left: 4px solid #ff9800;
-    border-radius: 4px;
-    padding: 0.8em 1.2em;
-    margin: 0.5em 0 1.5em 0;
-    display: flex;
-    align-items: center;
-    gap: 0.8em;
-}
-.je-dep-banner.je-hidden {
-    display: none !important;
-}
-.je-dep-banner-icon {
-    color: #ff9800;
-    font-size: 22px;
-    flex-shrink: 0;
-}
-.je-dep-banner-text {
-    font-size: 0.9em;
-}
-.je-dep-banner-hint {
-    opacity: 0.8;
-    font-size: 0.9em;
-}
-
-/* ---------------------------------------------------------------------------
-   Corrupt banner (created by JS)
-   --------------------------------------------------------------------------- */
-.arr-corrupt-banner {
-    padding: 0.8em 1em;
-    margin-bottom: 1em;
-    border: 1px solid #dc3545;
-    background: rgba(220,53,69,0.15);
-    border-radius: 4px;
-}
-.je-corrupt-detail {
-    margin-top: 0.3em;
-}
-.je-corrupt-reset-btn {
-    margin-top: 0.6em;
-}
-
-/* ---------------------------------------------------------------------------
-   Validation result divs (shown/hidden by JS — only base styles here)
-   --------------------------------------------------------------------------- */
-#seerrMappingsValidationResult {
-    margin-top: 0.8em;
-    padding: 0.8em 1em;
-    border-radius: 4px;
-    font-size: 0.9em;
-    line-height: 1.5;
-}
-/* je-validation-issue removed — not used in HTML (JS uses inline styles for validation result items) */
-
-/* je-custom-links-section is defined in the divider sections block above */
-.je-custom-links-input { margin-bottom: 1em; }
-.je-custom-links-desc  { margin-top: 0.5em; }
-
-/* ---------------------------------------------------------------------------
-   Details section summary (cursor + bold)
-   — same as .je-details-section > summary, kept as standalone for JS-created elements
-   --------------------------------------------------------------------------- */
-.je-details-section-summary {
-    cursor: pointer;
-    font-weight: bold;
-}
-
-/* ---------------------------------------------------------------------------
-   Permission audit table
-   --------------------------------------------------------------------------- */
-.je-audit-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.85em;
-    margin-top: 0.5em;
-}
-.je-audit-table th {
-    text-align: left;
-    padding: 6px 10px;
-    border-bottom: 1px solid rgba(255,255,255,0.15);
-    color: rgba(255,255,255,0.6);
-    font-weight: 600;
-    font-size: 0.8em;
-    text-transform: uppercase;
-    letter-spacing: 0.4px;
-}
-.je-audit-table td {
-    padding: 8px 10px;
-    border-bottom: 1px solid rgba(255,255,255,0.06);
-    vertical-align: middle;
-}
-.je-audit-table tr:last-child td { border-bottom: none; }
-.je-audit-row-ok td { opacity: 0.6; }
-
-.je-audit-row-warn td:nth-child(2),
-.je-audit-row-ok td:nth-child(2) {
-    white-space: nowrap;
+.je-apply-hint {
     text-align: center;
+    color: #888;
+    font-size: 0.85em;
+    margin-top: 10px;
+    grid-column: 1 / -1;
 }
-.je-audit-username { font-weight: 500; }
-.je-audit-status-ok {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 999px;
+
+.je-ft-warning-title { display: block; margin-bottom: 0.3em; }
+.je-ft-warning-link { color: #ff6b6b; text-decoration: underline; }
+.je-ft-warning-code { background: var(--je-surface-3); padding: 2px 6px; border-radius: 3px; }
+.je-ft-warning-actions { display: flex; gap: 10px; margin-top: 10px; }
+
+.dep-hint-text {
+    color: #ffc107;
     font-size: 0.8em;
-    font-weight: 600;
-    background: rgba(82,181,75,0.15);
-    color: #52b54b;
+    margin-top: 4px;
+    display: block;
+    font-style: italic;
 }
-.je-audit-status-warn {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 999px;
-    font-size: 0.8em;
-    font-weight: 600;
-    background: rgba(229,160,13,0.15);
-    color: #e5a00d;
+.dep-required-icon { vertical-align: middle; margin-left: 6px; }
+
+/* ---------------------------------------------------------------------------
+   Docs tab — embedded live docs iframe
+   Breaks out of the form's 1400px max-width so the iframe goes edge-to-edge.
+   Keeps only a thin single-line header with the title + "open in new tab".
+   --------------------------------------------------------------------------- */
+/* Docs tab takes the full width of the form (matching the tab bar above it)
+   and uses a single-row header + tall iframe with no fieldset chrome. */
+#docs.jellyfin-tab-content.active {
+    display: block;
+    width: 100%;
+    padding: 0;
+    gap: 0;
 }
-.je-audit-status-unlinked {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 999px;
-    font-size: 0.8em;
-    font-weight: 600;
-    background: rgba(102,102,102,0.15);
-    color: #999;
+.je-docs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 16px;
+    background: rgba(22, 22, 22, 0.94);
+    border-bottom: 1px solid var(--je-border);
 }
-.je-audit-issues { margin: 0; padding: 0; list-style: none; }
-.je-audit-issues li {
-    padding: 4px 0;
-    color: rgba(255,255,255,0.7);
+.je-docs-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    font-size: 1.05em;
+    color: var(--primary-accent-color, #00a4dc);
+}
+.je-docs-title .je-legend-icon { font-size: 20px !important; }
+.je-docs-open-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--primary-accent-color, #00a4dc);
+    text-decoration: none;
     font-size: 0.9em;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: background 0.15s ease;
 }
-.je-audit-issues li::before {
-    content: '• ';
-    color: #e5a00d;
+.je-docs-open-link:hover { background: var(--je-surface-2); text-decoration: underline; }
+.je-docs-open-link .material-icons { font-size: 16px !important; }
+.je-docs-iframe {
+    width: 100%;
+    height: calc(100vh - 170px);
+    min-height: 520px;
+    border: 0;
+    background: #0f0f0f;
+    display: block;
 }
 
-tr:has(.je-audit-status-unlinked) .je-audit-issues li::before {
-    color: #999;
+/* ---------------------------------------------------------------------------
+   Setting description visibility toggle
+   --------------------------------------------------------------------------- */
+body.je-hide-descriptions .je-setting-description { display: none !important; }
+body.je-hide-descriptions .je-overview-intro,
+body.je-hide-descriptions .je-tab-intro { display: none !important; }
+
+/* Per-service action row on the *arr tab — [+ Add instance] [Validate Mappings] */
+.je-arr-action-row {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-top: 8px;
+}
+.je-arr-action-row > button { width: fit-content; margin: 0; }
+.je-desc-toggle { display: inline-flex; align-items: center; gap: 4px; }
+.je-desc-toggle .material-icons { font-size: 18px !important; }
+.je-desc-toggle[aria-pressed="true"] .material-icons { color: var(--primary-accent-color, #00a4dc); }
+.je-desc-toggle-off { opacity: 0.75; }
+.je-desc-toggle-off:hover { opacity: 1; }
+
+/* ---------------------------------------------------------------------------
+   Collapsible info banners
+   When "Descriptions" is off, every .je-info-banner-inline(-center) folds
+   into a small clickable (i) next to its anchor (fieldset legend or the
+   checkbox label container). Clicking the icon expands the banner(s) in
+   place; clicking outside closes them. Banners inside a .je-setting-
+   description are re-surfaced via :has() without also revealing the plain
+   fieldDescription text in the same container.
+   --------------------------------------------------------------------------- */
+.je-banner-trigger {
+    display: none;
+    align-items: center;
+    vertical-align: middle;
+    margin-left: 6px;
+    padding: 2px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--primary-accent-color, #00a4dc);
+    cursor: pointer;
+    opacity: 0.75;
+    transition: opacity 0.15s ease, background 0.15s ease;
+}
+.je-banner-trigger:hover { opacity: 1; }
+.je-banner-trigger[aria-expanded="true"] {
+    background: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 20%, transparent);
+    opacity: 1;
+}
+.je-banner-trigger .material-icons {
+    font-size: 18px !important;
+    line-height: 1;
+    vertical-align: middle;
 }
 
+body.je-hide-descriptions .je-banner-trigger { display: inline-flex; }
+body.je-hide-descriptions .je-banner-managed { display: none; }
+body.je-hide-descriptions .je-banner-managed.je-banner-open { display: block; }
+
+/* Per-banner gating: hide the banner + surface the trigger icon when the
+   gating parent checkbox (.je-setting-description[data-desc-for="X"] where
+   #X is a checkbox) is unchecked. Same UX as descriptions-off, but scoped
+   to a single banner group rather than global. */
+.je-banner-managed.je-banner-parent-off:not(.je-banner-open) { display: none; }
+.je-banner-managed.je-banner-parent-off.je-banner-open { display: block; }
+.je-banner-trigger.je-banner-parent-off { display: inline-flex; }
+
+/* Surface the parent description container only for sections whose banner
+   is explicitly opened, and suppress the plain description text within. */
+body.je-hide-descriptions .je-setting-description:has(.je-banner-managed.je-banner-open) {
+    display: block !important;
+}
+body.je-hide-descriptions .je-setting-description:has(.je-banner-managed.je-banner-open) > .fieldDescription {
+    display: none;
+}
+
+/* ---------------------------------------------------------------------------
+   Gated help blocks
+   --------------------------------------------------------------------------- */
+[data-gated-by][hidden] { display: none !important; }
+
+/* ---------------------------------------------------------------------------
+   Dynamic descriptions — hide install-only content when the relevant
+   integration plugin is detected on the server. Body classes are toggled
+   by checkInstalledPlugins() in configPage.html.
+   --------------------------------------------------------------------------- */
+body.je-has-customtabs   .je-needs-customtabs   { display: none !important; }
+body.je-has-pluginpages  .je-needs-pluginpages  { display: none !important; }
+body.je-has-introskipper .je-needs-introskipper { display: none !important; }
+
+/* Media Tags rows — pair an Enable toggle with its Position dropdown on
+   one row so the relationship is obvious without an "Advanced" accordion.
+   Falls to a stacked layout on narrow viewports so the dropdown doesn't
+   shrink unreadably. */
+.je-tag-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+.je-tag-row > .checkboxContainer {
+    flex: 1 1 200px;
+    margin: 0;
+    min-width: 0;
+}
+.je-tag-row > .je-tag-position {
+    flex: 0 0 auto;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.je-tag-row > .je-tag-position .inputLabel {
+    font-size: 0.85em;
+    margin: 0;
+    white-space: nowrap;
+}
+.je-tag-row > .je-tag-position .emby-select {
+    min-width: 140px;
+}
+@media (max-width: 600px) {
+    .je-tag-row > .je-tag-position {
+        flex: 1 1 100%;
+    }
+}
+
+/* Custom Tabs auto-manage toggles — hidden by default. Revealed only when
+   the Custom Tabs plugin is detected AND its config schema matches what
+   Jellyfin Enhanced knows how to write. JS sets `je-has-customtabs-compat`
+   on body after a successful schema validation. */
+.je-customtabs-automanage { display: none; }
+body.je-has-customtabs-compat .je-customtabs-automanage { display: block; }
+
+/* "✓ Plugin detected" badges — hidden by default, revealed when the
+   matching body class is present. Authors place
+   <span class="je-installed-badge" data-plugin="customtabs">…</span>
+   wherever a positive confirmation makes sense. */
+.je-installed-badge { display: none; }
+body.je-has-customtabs   .je-installed-badge[data-plugin="customtabs"]   { display: inline-flex; }
+body.je-has-pluginpages  .je-installed-badge[data-plugin="pluginpages"]  { display: inline-flex; }
+body.je-has-introskipper .je-installed-badge[data-plugin="introskipper"] { display: inline-flex; }
+body.je-has-kefintweaks  .je-installed-badge[data-plugin="kefintweaks"]  { display: inline-flex; }
+body.je-has-filetransformation .je-installed-badge[data-plugin="filetransformation"] { display: inline-flex; }
+.je-installed-badge {
+    align-items: center;
+    gap: 4px;
+    color: #4caf50;
+    font-size: 0.85em;
+    font-weight: 500;
+    margin-left: 8px;
+    vertical-align: middle;
+}
+.je-installed-badge .material-icons { font-size: 16px !important; }
+
+/* ---------------------------------------------------------------------------
+   Permission Audit (Seerr → Permission Audit)
+   Card-list layout that reflows cleanly on narrow viewports instead of a
+   three-column table. Status shown via color-coded chips + a left border
+   accent per card. OK users collapsed behind a <details> as name pills.
+   --------------------------------------------------------------------------- */
 .je-audit-summary {
-    font-size: 0.95em;
-    color: rgba(255,255,255,0.5);
-    margin-bottom: 0.75em;
+    font-size: 0.92em;
+    color: var(--je-text-strong);
+    margin-bottom: 12px;
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 10%, transparent);
+    border-left: 3px solid var(--primary-accent-color, #00a4dc);
+    border-radius: 6px;
+    line-height: 1.4;
 }
-.je-shortcut-flex      { flex: 1; }
-.je-blocked-count      { opacity: 0.7; font-weight: normal; }
-.je-elsewhere-subtitle { font-size: 0.9em; }
-.je-loading-text       { opacity: 0.5; }
-.je-bold-link          { text-decoration: underline; font-weight: bolder; }
+.je-audit-summary-title { font-weight: 600; }
+.je-audit-summary-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+}
+.je-audit-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 0.82em;
+    font-weight: 600;
+    white-space: nowrap;
+}
+.je-audit-chip .material-icons { font-size: 14px !important; }
+.je-audit-chip-warn     { background: rgba(229,160,13,0.18); color: #e5a00d; }
+.je-audit-chip-unlinked { background: rgba(158,158,158,0.18); color: #bdbdbd; }
+.je-audit-chip-ok       { background: rgba(82,181,75,0.18); color: #52b54b; }
 
-/* Screenshot details/summary */
-.je-screenshot-details  { margin: 0.5em 0; }
-.je-screenshot-summary  { cursor: pointer; color: #00a4dc; }
+.je-audit-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 0 0 12px 0;
+}
+.je-audit-card {
+    background: var(--je-surface-1);
+    border: 1px solid var(--je-border);
+    border-left-width: 3px;
+    border-radius: 8px;
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.je-audit-card-warn     { border-left-color: #e5a00d; }
+.je-audit-card-unlinked { border-left-color: #9e9e9e; }
+.je-audit-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+.je-audit-card-user {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    min-width: 0;
+    word-break: break-word;
+}
+.je-audit-card-user .material-icons {
+    font-size: 18px !important;
+    color: var(--je-text-subtle);
+}
+.je-audit-card-issues {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.je-audit-card-issues li {
+    color: var(--je-text-strong);
+    font-size: 0.88em;
+    padding-left: 18px;
+    position: relative;
+    line-height: 1.4;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+}
+.je-audit-card-issues li::before {
+    content: '•';
+    position: absolute;
+    left: 6px;
+    top: 0;
+    color: #e5a00d;
+    font-weight: 700;
+}
+.je-audit-card-unlinked .je-audit-card-issues li::before { color: #9e9e9e; }
+
+.je-audit-ok-section { margin-top: 6px; }
+.je-audit-ok-section > summary {
+    cursor: pointer;
+    color: var(--je-text-muted);
+    font-size: 0.88em;
+    padding: 6px 2px;
+    user-select: none;
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+.je-audit-ok-section > summary::-webkit-details-marker { display: none; }
+.je-audit-ok-section > summary::before {
+    content: 'chevron_right';
+    font-family: 'Material Icons';
+    font-size: 18px;
+    line-height: 1;
+    transition: transform 0.15s ease;
+}
+.je-audit-ok-section[open] > summary::before { transform: rotate(90deg); }
+.je-audit-ok-section > summary:hover { color: var(--je-text-strong); }
+.je-audit-ok-names {
+    list-style: none;
+    margin: 8px 0 0 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.je-audit-ok-names li {
+    padding: 3px 10px;
+    background: rgba(82,181,75,0.12);
+    color: #52b54b;
+    border-radius: 999px;
+    font-size: 0.82em;
+    word-break: break-word;
+}
+.je-audit-error {
+    color: #f44336;
+    padding: 10px 14px;
+    background: rgba(244,67,54,0.08);
+    border-left: 3px solid #f44336;
+    border-radius: 6px;
+}
+
+@media (max-width: 540px) {
+    .je-audit-summary { padding: 8px 10px; font-size: 0.88em; }
+    .je-audit-card { padding: 10px 12px; }
+    .je-audit-card-header { flex-direction: column; align-items: flex-start; gap: 6px; }
+    .je-audit-chip { font-size: 0.78em; padding: 2px 8px; }
+}
+
+/* Responsive utility */
+#keyboard .configSection > div[style*="display:flex"] {
+    flex-wrap: wrap;
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+    .je-save-dock {
+        flex-direction: column;
+        bottom: 10px;
+        width: 90%;
+        border-radius: 20px;
+        padding: 12px;
+    }
+    .je-save-dock .je-save-dock-btn { width: 100%; justify-content: center; }
+    .je-tab-bar { padding: 10px 0; }
+    .jellyfin-tab-button { padding: 8px 14px; }
+    .je-tab-icon { font-size: 18px !important; }
+
+    /* The tab content grid uses minmax(480px, 1fr) for desktop multi-column.
+       On viewports narrower than the 480px min, the grid forces horizontal
+       overflow (descriptions get cut off, page scrolls sideways). Collapse
+       to single column under 768px so cards stack cleanly. */
+    .jellyfin-tab-content.active {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+    /* Grid items default to `min-width: auto` (their intrinsic content width).
+       Banners and fieldsets containing flex layouts have a wide intrinsic min
+       (the longest line of unwrapped text), which forces grid items wider than
+       the column even with `1fr`. Set `min-width: 0` so items honor the column
+       width and let their text/contents wrap inside. */
+    .jellyfin-tab-content.active > * {
+        min-width: 0;
+    }
+
+    /* Flex children default to min-width: auto, which equals their intrinsic
+       content width. Inside info banners, that means the inner text div refuses
+       to shrink below the longest line — pushing the whole page wider than the
+       viewport. Force `min-width: 0` so flex children honor their parent's
+       width, and force long words/URLs to break instead of overflowing. */
+    .je-info-banner > *,
+    .je-info-banner-inline > *,
+    .je-info-banner-inline-center > *,
+    .je-info-banner-compact > *,
+    .je-note-banner > *,
+    .je-mobile-banner > *,
+    .je-danger-banner > *,
+    .je-purple-banner > *,
+    .je-dep-banner > *,
+    .je-splash-info-banner > *,
+    .je-info-banner-row > * {
+        min-width: 0;
+    }
+    .fieldDescription, .je-setting-description {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+    /* Same anti-overflow for the form itself in case any ancestor's min-width
+       forces it wide; let it shrink to viewport. */
+    #JellyfinEnhancedForm {
+        min-width: 0;
+    }
+
+    /* Header row: title + the two action buttons + search. The action
+       buttons ("Docs & Help" / "Descriptions") were wrapping to 3 lines
+       and overflowing the viewport. Shrink padding + let the title row
+       wrap so buttons drop below if needed. */
+    .sectionTitleContainer { gap: 8px; }
+    .sectionTitleContainer h2 { font-size: 1.4em; flex: 1 1 100%; }
+    .je-header-title-row {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+    .je-help-link, .je-desc-toggle {
+        padding: 6px 10px;
+        font-size: 0.85em;
+    }
+    #settingsSearchContainer {
+        flex: 1 1 100%;
+        max-width: 100%;
+    }
+}
+
+/* Sub-mobile: hide button labels on the very narrowest viewports so the
+   header stays compact even on iPhone SE / Android Mini. The icon alone
+   stays clickable; `aria-label` + `title` on the button surface the label
+   for assistive tech and on long-press for users who need it. Tap target
+   is bumped to meet WCAG 2.1 AAA (44×44 CSS px). */
+@media (max-width: 420px) {
+    .je-help-link .je-help-link-label,
+    .je-desc-toggle .je-desc-toggle-label {
+        display: none;
+    }
+    .je-help-link,
+    .je-desc-toggle {
+        min-width: 44px;
+        min-height: 44px;
+        padding: 10px;
+        justify-content: center;
+    }
+    .je-help-link .material-icons,
+    .je-desc-toggle .material-icons { font-size: 20px !important; }
+    .sectionTitleContainer h2 { font-size: 1.25em; }
+}
+
+#settingsSearchClear { display: none; }
+#settingsSearchClear.show { display: flex; }
+
+/* =========================================================================
+   Timing preview buttons (Playback tab → Shortcuts Panel & Toast Timing)
+   Lets admins preview how long the shortcuts panel or a toast stays visible
+   with the current (unsaved) values from the form inputs.
+   ========================================================================= */
+
+/* Row wrapper lives OUTSIDE .je-setting-description so the preview buttons
+   stay visible even when "Descriptions" is toggled off (which hides every
+   .je-setting-description via body.je-hide-descriptions). Padding-left
+   mirrors the description indent so it lines up visually when descriptions
+   are on; margin-top collapses a bit when the preceding description is
+   hidden so it doesn't look stranded. */
+.je-timing-test-row {
+    padding-left: 14px;
+    margin: 2px 0 12px 0;
+}
+body.je-hide-descriptions .je-timing-test-row {
+    margin-top: 8px;
+}
+.je-timing-test-btn {
+    display: inline-flex !important;
+    align-items: center;
+    gap: 6px;
+}
+.je-timing-test-btn .material-icons {
+    font-size: 1.1em;
+}
+
+/* Full-screen preview of the shortcuts panel autoclose timing — card styled
+   to match the real panel in js/enhanced/ui.js: solid rgb(24,24,24) bg,
+   subtle white border, 16px radius, centered on screen, backdrop blur. */
+.je-preview-panel-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--je-overlay-hard);
+    z-index: 99999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: je-preview-fade-in 0.2s ease;
+}
+.je-preview-panel-card {
+    background: rgb(24, 24, 24);
+    color: #fff;
+    border: 1px solid var(--je-border);
+    border-radius: 16px;
+    padding: 24px 28px;
+    min-width: 350px;
+    max-width: min(520px, 90vw);
+    max-height: 90vh;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(30px);
+    -webkit-backdrop-filter: blur(30px);
+    font-size: 14px;
+    font-family: inherit;
+}
+.je-preview-panel-title {
+    font-size: 1.15em;
+    font-weight: 600;
+    margin: 0 0 10px 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--primary-accent-color, #00a4dc);
+}
+.je-preview-panel-body {
+    line-height: 1.5;
+    margin: 0 0 18px 0;
+    opacity: 0.92;
+}
+.je-preview-panel-countdown {
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    font-weight: 700;
+    color: var(--primary-accent-color, #00a4dc);
+    white-space: nowrap;
+}
+.je-preview-panel-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+/* Bottom-right toast preview — mirrors the real JE.toast() in js/enhanced/ui.js:
+   same position, dark gradient bg, accent border, backdrop blur, and
+   slide-in-from-right transition (not a keyframe animation). */
+.je-preview-toast {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    transform: translateX(calc(100% + 20px));
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.9), rgba(40, 40, 40, 0.9));
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: 8px;
+    z-index: 99999;
+    font-size: clamp(13px, 2vw, 16px);
+    font-weight: 500;
+    text-shadow: -1px -1px 10px black;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(30px);
+    -webkit-backdrop-filter: blur(30px);
+    border: 1px solid var(--primary-accent-color, rgba(255, 255, 255, 0.1));
+    max-width: clamp(280px, 80vw, 350px);
+    transition: transform 0.3s ease-out;
+    pointer-events: none;
+}
+.je-preview-toast.je-shown {
+    transform: translateX(0);
+}
+
+@keyframes je-preview-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .je-preview-panel-overlay { animation: none; }
+    .je-preview-toast { transition: none; }
+}

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -43,6 +43,15 @@
     --je-accent-tint-10: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 10%, transparent);
     --je-accent-tint-20: color-mix(in srgb, var(--primary-accent-color, #00a4dc) 20%, transparent);
     --je-accent-border:  color-mix(in srgb, var(--primary-accent-color, #00a4dc) 40%, transparent);
+    /* Icon plate — the small background under brand SVGs (Seerr tab
+       icon, Sonarr/Radarr/Bazarr legend icons) so their transparent
+       regions don't bleed through the underlying surface (especially
+       the accent color on an active tab). Soft off-white in dark
+       themes; dark plate in .je-light-theme below (otherwise the
+       white-bodied Sonarr/Bazarr logos merge into the light page
+       background). */
+    --je-icon-plate-bg:      rgba(255, 255, 255, 0.94);
+    --je-icon-plate-shadow:  0 1px 2px rgba(0, 0, 0, 0.25);
 }
 
 #JellyfinEnhancedPage.je-light-theme {
@@ -64,6 +73,12 @@
     --je-overlay-soft:   rgba(0, 0, 0, 0.06);
     --je-overlay:        rgba(0, 0, 0, 0.1);
     --je-overlay-hard:   rgba(0, 0, 0, 0.35);
+    /* Dark plate on light theme — white-bodied Sonarr/Bazarr logos
+       would merge into a light-theme page without this. Picks up a
+       small amount of the user's accent so the plate harmonizes
+       instead of reading as a stark dark chip. */
+    --je-icon-plate-bg:      color-mix(in srgb, var(--primary-accent-color, #00a4dc) 18%, #1a202c);
+    --je-icon-plate-shadow:  0 1px 2px rgba(0, 0, 0, 0.18);
 }
 
 /* OS-level light preference as a fallback: only kicks in when the JS
@@ -89,6 +104,8 @@
         --je-overlay-soft:   rgba(0, 0, 0, 0.06);
         --je-overlay:        rgba(0, 0, 0, 0.1);
         --je-overlay-hard:   rgba(0, 0, 0, 0.35);
+        --je-icon-plate-bg:      color-mix(in srgb, var(--primary-accent-color, #00a4dc) 18%, #1a202c);
+        --je-icon-plate-shadow:  0 1px 2px rgba(0, 0, 0, 0.18);
     }
 }
 
@@ -272,10 +289,14 @@
     height: 20px;
     margin-right: 8px;
     vertical-align: -5px;
-    background: #fff;
+    /* Same theme-aware plate as the tab icons (see --je-icon-plate-bg
+       definition near the top of this file) — keeps Sonarr/Radarr/
+       Bazarr brand logos legible on both dark and light themes. */
+    background: var(--je-icon-plate-bg);
     border-radius: 4px;
     padding: 2px;
     box-sizing: content-box;
+    box-shadow: var(--je-icon-plate-shadow);
 }
 
 /* Quick Actions grid */
@@ -600,14 +621,16 @@
     width: 18px;
     height: 18px;
     pointer-events: none;
-    /* White plate so the brand SVG (which ships with transparent regions)
-       doesn't go see-through when the tab's background flips to the accent
-       color on the active state. Matches the plate treatment used on
-       service-status cards. */
-    background: #fff;
+    /* Brand SVGs ship with transparent regions; without a plate, the
+       active-tab accent background bleeds through those gaps. Plate
+       color is theme-aware: off-white on dark themes, dark accent-
+       tinted on .je-light-theme. Soft drop-shadow gives depth so the
+       chip doesn't read as a stark stamp. */
+    background: var(--je-icon-plate-bg);
     border-radius: 4px;
     padding: 2px;
     box-sizing: content-box;
+    box-shadow: var(--je-icon-plate-shadow);
 }
 .jellyfin-tab-button .je-tab-icon {
     font-size: 20px !important;
@@ -1530,6 +1553,32 @@ body.je-has-introskipper .je-needs-introskipper { display: none !important; }
 @media (max-width: 600px) {
     .je-tag-row > .je-tag-position {
         flex: 1 1 100%;
+    }
+}
+
+/* Two-column input pairs — side-by-side input+description blocks on wide
+   viewports, stacking under the mobile breakpoint. Each .je-two-col-pair
+   owns one input and its description so the description sits directly
+   under its input instead of spanning the whole grid. */
+.je-two-col-pairs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+    align-items: start;
+}
+.je-two-col-pair {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+.je-two-col-pair > .inputContainer,
+.je-two-col-pair > .je-setting-description {
+    margin: 0;
+}
+@media (max-width: 720px) {
+    .je-two-col-pairs {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -800,9 +800,14 @@
 
 /* Feature-enabler (master-toggle) checkboxes — visually pronounced so
    the sub-options that follow read as OPTIONS of that feature, not
-   independent peers. Uses :has() to target specific known master IDs;
-   modern browsers (Chrome 105+, Safari 15.4+, Firefox 121+) support
-   it, older fallback is the plain checkbox look (still functional). */
+   independent peers. Scoped to one PRIMARY toggle per fieldset (the
+   "enable this page/feature entirely" switch). Mid-fieldset mode
+   selectors and sub-feature anchors stay plain — the dashed-indent
+   `je-setting-dep` pattern already signals their parent→child
+   relationships without visually overloading the page.
+   Uses :has() to target specific known master IDs; modern browsers
+   (Chrome 105+, Safari 15.4+, Firefox 121+) support it, older
+   fallback is the plain checkbox look (still functional). */
 .configSection > .checkboxContainer:has(> label > input#downloadsPageEnabled),
 .configSection > .checkboxContainer:has(> label > input#calendarPageEnabled),
 .configSection > .checkboxContainer:has(> label > input#bookmarksEnabled),
@@ -811,11 +816,7 @@
 .configSection > .checkboxContainer:has(> label > input#elsewhereEnabled),
 .configSection > .checkboxContainer:has(> label > input#randomButtonEnabled),
 .configSection > .checkboxContainer:has(> label > input#arrLinksEnabled),
-.configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled),
-.configSection > .checkboxContainer:has(> label > input#autoSeasonRequestEnabled),
-.configSection > .checkboxContainer:has(> label > input#autoMovieRequestEnabled),
-.configSection > .checkboxContainer:has(> label > input#qualityTagsEnabled),
-.configSection > .checkboxContainer:has(> label > input#tagCacheServerMode) {
+.configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled) {
     background: linear-gradient(90deg,
         color-mix(in srgb, var(--primary-accent-color, #00a4dc) 14%, transparent) 0%,
         color-mix(in srgb, var(--primary-accent-color, #00a4dc) 2%, transparent) 100%);
@@ -830,11 +831,7 @@
 .configSection > .checkboxContainer:has(> label > input#elsewhereEnabled) label > span,
 .configSection > .checkboxContainer:has(> label > input#randomButtonEnabled) label > span,
 .configSection > .checkboxContainer:has(> label > input#arrLinksEnabled) label > span,
-.configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled) label > span,
-.configSection > .checkboxContainer:has(> label > input#autoSeasonRequestEnabled) label > span,
-.configSection > .checkboxContainer:has(> label > input#autoMovieRequestEnabled) label > span,
-.configSection > .checkboxContainer:has(> label > input#qualityTagsEnabled) label > span,
-.configSection > .checkboxContainer:has(> label > input#tagCacheServerMode) label > span {
+.configSection > .checkboxContainer:has(> label > input#arrTagsSyncEnabled) label > span {
     font-weight: 600;
     font-size: 1.02em;
     color: #fff;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -210,21 +210,32 @@
 }
 #settingsSearchContainer > div {
     position: relative;
-    display: flex;
-    align-items: center;
+    /* display: block is enough — the icon / count / clear are all
+       absolute-positioned. A flex container tried to treat them as
+       items and relied on `top: auto` resolving to the static position
+       under align-items: center, which some browsers render with
+       sub-pixel offsets. Using block + explicit top: 50% /
+       translateY(-50%) on each overlay is deterministic across
+       browsers. */
+    display: block;
 }
 #settingsSearchInput {
     width: 100%;
-    padding: 10px 90px 10px 35px !important; /* Pad right to fit count and clear btn */
+    /* Pad left for the search icon, right for count + clear button. */
+    padding: 10px 90px 10px 40px !important;
     background: var(--je-overlay);
     border: 1px solid var(--je-border);
     border-radius: 20px;
     color: #eee;
     font-size: 0.9em;
     outline: none;
-    transition: all 0.3s ease;
+    transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
     box-shadow: inset 0 2px 4px rgba(0,0,0,0.1);
     box-sizing: border-box;
+    /* Ensure the input paints BELOW the overlay icons so its selection
+       highlight (native browser paint) doesn't cover them. */
+    position: relative;
+    z-index: 0;
 }
 #settingsSearchInput:focus {
     background: var(--je-overlay-hard);
@@ -233,23 +244,36 @@
 }
 .je-search-icon {
     position: absolute;
-    left: 10px;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
     color: var(--je-text-subtle);
     pointer-events: none;
-    font-size: 1.2em;
+    font-size: 18px !important;
+    line-height: 1;
+    /* Sit above the input so the native selection-highlight paint
+       (which can cover the input's full content box) never masks the
+       icon. */
+    z-index: 1;
 }
 #settingsSearchCount {
     display: none;
     position: absolute;
     right: 40px;
+    top: 50%;
+    transform: translateY(-50%);
     color: var(--je-text-muted);
     font-size: 0.8em;
     font-weight: 500;
+    pointer-events: none;
+    z-index: 1;
 }
 #settingsSearchClear {
     display: none;
     position: absolute;
     right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
     background: var(--je-surface-3);
     border: none;
     color: #fff;
@@ -261,6 +285,7 @@
     align-items: center;
     justify-content: center;
     transition: background 0.2s;
+    z-index: 2;
 }
 #settingsSearchClear:hover {
     background: #dc3545;
@@ -1122,6 +1147,15 @@
 .arr-instance-disabled > summary .arr-instance-summary-name {
     text-decoration: line-through;
     color: var(--je-text-muted);
+}
+/* Belt-and-braces disable for the body — the form controls already
+   carry the HTML `disabled` attribute (see setBodyDisabled in
+   createInstanceCard), but pointer-events:none also blocks click
+   handlers attached via addEventListener (the Remove button's confirm
+   dialog, etc.) and prevents hover/focus states on the card while
+   the instance is off. */
+.arr-instance-disabled > .arr-instance-card-body {
+    pointer-events: none;
 }
 .arr-instance-remove {
     background: transparent;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1219,6 +1219,21 @@
    Search Highlight Utilities
    --------------------------------------------------------------------------- */
 .je-search-hidden { display: none !important; }
+
+/* In search mode the form becomes a flex column so tab-contents
+   whose tab name itself matches the query can hoist to the top via
+   order: -1 — searching "elsewhere" should surface the Elsewhere
+   tab above other tabs that merely mention "Elsewhere" in service-
+   status labels. Outside search mode, only a single tab-content is
+   active and the form's default block flow is fine. */
+#JellyfinEnhancedForm.je-search-mode {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+#JellyfinEnhancedForm.je-search-mode > .jellyfin-tab-content.je-tab-name-match {
+    order: -1;
+}
 .je-search-match {
     background-color: rgba(255,200,0,0.35);
     color: #fff;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1446,8 +1446,18 @@ body.je-hide-descriptions .je-tab-intro { display: none !important; }
 }
 .je-arr-action-row > button { width: fit-content; margin: 0; }
 .je-desc-toggle { display: inline-flex; align-items: center; gap: 4px; }
-.je-desc-toggle .material-icons { font-size: 18px !important; color: var(--je-text-primary, #fff); }
-.je-desc-toggle[aria-pressed="true"] .material-icons { color: var(--primary-accent-color, #00a4dc); }
+/* Icon always inherits the button's own text color via currentColor —
+   earlier the pressed state used `var(--primary-accent-color)` which
+   vanishes on themes whose raised-button background also uses the
+   accent color (any "Jellyfish"-style accent-filled button theme).
+   Use the button label's color for the icon so it stays visible on
+   every theme, and mark the pressed state with an accent ring on the
+   button itself — the ring reads against any bg because it's painted
+   outside the button. */
+.je-desc-toggle .material-icons { font-size: 18px !important; color: currentColor; }
+.je-desc-toggle[aria-pressed="true"] {
+    box-shadow: 0 0 0 2px var(--primary-accent-color, #00a4dc);
+}
 .je-desc-toggle-off { opacity: 0.75; }
 .je-desc-toggle-off:hover { opacity: 1; }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1991,6 +1991,10 @@
                 // Restore (or reset) the scroll position after the new tab's
                 // content is in the DOM. rAF waits for the layout pass so the
                 // saved scrollY actually addresses the right document height.
+                // NOTE: load-bearing for the service-status card deep-link at
+                // renderServiceStatusDashboard (scrollTo handler uses a
+                // double-rAF to run after this restore). If this rAF goes
+                // away or gains an extra frame, update that handler to match.
                 const saved = _jeTabScroll[tabId];
                 requestAnimationFrame(() => _jeSetScrollTop(saved || 0));
                 _jePrevTabId = tabId;
@@ -2703,7 +2707,7 @@
                 hasPluginPages        = probe('pluginPages',        ['Plugin Pages']);
                 hasCustomTabs         = probe('customTabs',         ['Custom Tabs']);
                 hasIntroSkipper       = probe('introSkipper',       ['Intro Skipper', 'SkipIntro']);
-                hasInPlayerEpisodePreview = probe('inPlayerEpisodePreview', ['In Player Episode Preview', 'InPlayerEpisodePreview']);
+                hasInPlayerEpisodePreview = probe('inPlayerEpisodePreview', ['In Player Episode Preview', 'In-Player Episode Preview', 'InPlayerEpisodePreview']);
 
                 // KefinTweaks installs as a web-mod (files in /config/KefinTweaks/
                 // injected via File Transformation into index.html), NOT as a
@@ -4493,44 +4497,87 @@
         })();
 
         // Apply the blurred background to .je-sticky-header only when the
-        // scroll container has actually scrolled — at scrollTop=0 the header
-        // stays transparent so it doesn't cover the Jellyfin top bar / user
-        // avatar. The scroll container is whichever ancestor of the form
-        // actually scrolls (usually Jellyfin's page view, occasionally the
-        // window itself on mobile).
+        // surrounding scroll container has actually scrolled — at scrollTop=0
+        // the header stays transparent so it doesn't cover the Jellyfin top
+        // bar / user avatar. We don't know ahead of time which element
+        // actually scrolls (Jellyfin's layout has several candidates: the
+        // page view wrapper, body, and window — and Jellyfin's `.scrollY`
+        // utility class decorates some non-scrolling nodes), so we attach
+        // scroll listeners to every reasonable candidate (matching ancestor
+        // + window) and read whichever reports a non-zero scroll position.
+        // This IIFE runs once at script parse; the listeners persist across
+        // SPA navigation since Jellyfin keeps the config page DOM alive.
         (function wireStickyHeaderScroll() {
             var header = document.querySelector('.je-sticky-header');
             if (!header) return;
-            function findScrollContainer(el) {
+            // Collect all overflow-y:auto|scroll ancestors as scroll-candidate
+            // nodes. We don't trust scrollHeight>clientHeight at bind time
+            // (async content hasn't landed yet); we don't pick just the
+            // first match (Jellyfin's .scrollY utility flags decorative
+            // containers that don't actually scroll). Listening on all
+            // matches plus window means whichever actually scrolls drives
+            // the class toggle.
+            function findScrollCandidates(el) {
+                var nodes = [];
                 var node = el && el.parentNode;
                 while (node && node !== document.body && node.nodeType === 1) {
-                    var style = getComputedStyle(node);
-                    var oy = style.overflowY;
-                    if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight) {
-                        return node;
-                    }
+                    var oy = getComputedStyle(node).overflowY;
+                    if (oy === 'auto' || oy === 'scroll') nodes.push(node);
                     node = node.parentNode;
                 }
-                return window;
+                return nodes;
             }
-            var container = findScrollContainer(header);
+            var candidates = findScrollCandidates(header);
             var ticking = false;
+            function currentScrollTop() {
+                var winTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+                var contTop = 0;
+                for (var i = 0; i < candidates.length; i++) {
+                    var n = candidates[i];
+                    // Skip detached nodes: their scrollTop freezes at the last
+                    // value, which would incorrectly pin `.je-is-scrolled` on
+                    // after the live scroller returns to top.
+                    if (!n.isConnected) continue;
+                    var t = n.scrollTop || 0;
+                    if (t > contTop) contTop = t;
+                }
+                return winTop > contTop ? winTop : contTop;
+            }
             function read() {
-                var top = container === window
-                    ? (window.pageYOffset || document.documentElement.scrollTop || 0)
-                    : container.scrollTop;
-                header.classList.toggle('je-is-scrolled', top > 4);
-                ticking = false;
+                try {
+                    header.classList.toggle('je-is-scrolled', currentScrollTop() > 4);
+                } catch (e) {
+                    // Belt-and-braces: reading scrollTop and toggling a class
+                    // on a detached node doesn't normally throw, but if it
+                    // ever does (custom element, closed shadow root, etc.)
+                    // we don't want the rAF pipeline to wedge on `ticking`.
+                    console.warn('[JE] sticky-header read failed:', e);
+                } finally {
+                    // Always reset `ticking` so the next scroll event can
+                    // schedule a fresh rAF, even if read() threw above.
+                    ticking = false;
+                }
             }
             function onScroll() {
                 if (ticking) return;
                 ticking = true;
                 requestAnimationFrame(read);
             }
-            container.addEventListener('scroll', onScroll, { passive: true });
-            // Prior listeners from a previous pageshow may still be live —
-            // removeEventListener is a no-op when none match, and idempotent
-            // when one does, so re-adding is safe across SPA re-entries.
+            // Always listen on window (covers document-scrolling layouts) and
+            // on each overflow-declared ancestor (covers mid-tree scrollers).
+            // If Jellyfin ever re-parents .je-sticky-header under a new
+            // scroll ancestor not present at bind time, the window listener
+            // is the fallback — on document-scrolling layouts it will fire.
+            // For container-scrolling layouts after a re-parent, the blur
+            // would fail to update, but `console.warn` below at least makes
+            // the "no candidates found" case observable.
+            window.addEventListener('scroll', onScroll, { passive: true });
+            if (candidates.length === 0) {
+                console.warn('[JE] sticky-header: no overflow:auto|scroll ancestors found; relying on window scroll only.');
+            }
+            candidates.forEach(function(n) {
+                n.addEventListener('scroll', onScroll, { passive: true });
+            });
             read();
         })();
 
@@ -5715,14 +5762,23 @@
                 btn.addEventListener('click', function() {
                     var tabBtn = document.querySelector('.jellyfin-tab-button[data-tab="' + c.tab + '"]');
                     if (tabBtn) tabBtn.click();
-                    // Optional deep-link: after the tab activates (next frame so
-                    // content has laid out), scroll the specific field into
-                    // view. Cards that don't set scrollTo land at the tab's
-                    // scroll-memory position as before.
+                    // Optional deep-link: after the tab activates AND
+                    // activateTab's own per-tab scroll-memory rAF has run
+                    // (double rAF), scroll the specific field into view.
+                    // activateTab schedules a rAF to restore scroll position,
+                    // so scheduling our scroll in the frame AFTER that wins
+                    // the race deterministically. Cards that don't set
+                    // scrollTo land at the tab's scroll-memory position.
                     if (c.scrollTo) {
                         requestAnimationFrame(function() {
-                            var target = document.querySelector(c.scrollTo);
-                            if (target) target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                            requestAnimationFrame(function() {
+                                var target = document.querySelector(c.scrollTo);
+                                if (target) {
+                                    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                                } else {
+                                    console.warn('[JE] service-status deep-link target not found:', c.scrollTo);
+                                }
+                            });
                         });
                     }
                 });

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -2099,9 +2099,6 @@
                 if (descToggleBtn) {
                     descToggleBtn.setAttribute('aria-pressed', show ? 'true' : 'false');
                     descToggleBtn.classList.toggle('je-desc-toggle-off', !show);
-                    // Label stays "Descriptions" regardless of state; the
-                    // adjacent pill (.je-desc-toggle-state) carries the
-                    // On/Off indicator.
                     const state = descToggleBtn.querySelector('.je-desc-toggle-state');
                     if (state) state.textContent = show ? 'On' : 'Off';
                 }
@@ -2164,11 +2161,6 @@
             });
 
 
-            // Focus/blur visuals are handled entirely by the CSS :focus rule —
-            // see #settingsSearchInput:focus in configPage.css. A prior JS
-            // version set inline styles here with hardcoded rgba(...) colors
-            // that fought with the theme-aware CSS vars and left stale styles
-            // after blur-with-value.
 
             /**
              * Collects searchable text from an element, including IDs, names, and data attributes.
@@ -3340,15 +3332,9 @@
             // Also re-renders the Overview Service Status card so a disabled instance
             // instantly shows as "Disabled" instead of a stale red/green badge.
             //
-            // When disabled, every form control inside the card body (name, URL,
-            // API key, URL mappings textarea, Test + Remove buttons) is marked
-            // with the `disabled` attribute so the instance is genuinely read-
-            // only while unchecked. Prior behaviour only dimmed the opacity —
-            // the fields were still fully editable, so an admin could type into
-            // a "disabled" instance and (since collectInstancesFromDom respects
-            // the Enabled flag on save) the edits would persist silently
-            // without the instance being used. CSS in configPage.css also
-            // applies `pointer-events: none` as a belt-and-braces layer.
+            // setBodyDisabled marks every form control inside the card body read-only when
+            // the toggle is off so edits can't silently persist — collectInstancesFromDom
+            // reads input values directly and respects the Enabled flag on save.
             function setBodyDisabled(disabled) {
                 body.querySelectorAll('input, textarea, button, select').forEach(function(el) {
                     if (disabled) {
@@ -4646,14 +4632,9 @@
                 try {
                     header.classList.toggle('je-is-scrolled', currentScrollTop() > 4);
                 } catch (e) {
-                    // Belt-and-braces: reading scrollTop and toggling a class
-                    // on a detached node doesn't normally throw, but if it
-                    // ever does (custom element, closed shadow root, etc.)
-                    // we don't want the rAF pipeline to wedge on `ticking`.
                     console.warn('[JE] sticky-header read failed:', e);
                 } finally {
-                    // Always reset `ticking` so the next scroll event can
-                    // schedule a fresh rAF, even if read() threw above.
+                    // Guarantees the rAF pipeline doesn't wedge on `ticking` if read() throws.
                     ticking = false;
                 }
             }
@@ -4662,14 +4643,8 @@
                 ticking = true;
                 requestAnimationFrame(read);
             }
-            // Always listen on window (covers document-scrolling layouts) and
-            // on each overflow-declared ancestor (covers mid-tree scrollers).
-            // If Jellyfin ever re-parents .je-sticky-header under a new
-            // scroll ancestor not present at bind time, the window listener
-            // is the fallback — on document-scrolling layouts it will fire.
-            // For container-scrolling layouts after a re-parent, the blur
-            // would fail to update, but `console.warn` below at least makes
-            // the "no candidates found" case observable.
+            // Always listen on window (document-scrolling layouts) and on
+            // each overflow-declared ancestor (mid-tree scrollers).
             window.addEventListener('scroll', onScroll, { passive: true });
             if (candidates.length === 0) {
                 console.warn('[JE] sticky-header: no overflow:auto|scroll ancestors found; relying on window scroll only.');

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -555,6 +555,14 @@
                     <fieldset>
                         <legend class="sectionTitle">Hidden Content</legend>
                         <div class="configSection">
+                            <div class="je-info-banner-inline-center" style="margin-bottom: 15px;">
+                                <div class="je-info-banner-row">
+                                    <i class="material-icons je-info-icon">info</i>
+                                    <div>
+                                        <strong>Hidden Content</strong> lets users hide individual items from Home and Library views and browse them from a dedicated Hidden Content page. Per-user state with a server-wide enable/disable kill switch.
+                                    </div>
+                                </div>
+                            </div>
                             <div class="checkboxContainer"><label><input id="hiddenContentEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Hidden Content</span></label></div>
                             <div class="je-setting-description" data-desc-for="hiddenContentEnabled">
                                 <div class="fieldDescription je-field-desc-xl">Enable or disable the Hidden Content feature server-wide. When disabled, hide buttons, filtering, sidebar navigation, and settings panel options are all removed. User data is preserved and restored when re-enabled.</div>
@@ -1265,10 +1273,10 @@
                     </div>
 
                     <fieldset>
-                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">tv</i>Sonarr</legend>
+                        <legend class="sectionTitle"><img class="je-legend-icon-img" src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/sonarr.svg" alt="">Sonarr</legend>
                         <div class="configSection">
                             <div class="je-setting-description" data-desc-for="sonarrInstancesList">
-                                <div class="fieldDescription">TV-show-focused *arr service. Add one instance per Sonarr server.</div>
+                                <div class="fieldDescription">Automated TV show collection management and monitoring. Add one instance per Sonarr server.</div>
                             </div>
                             <div id="sonarrInstancesList"></div>
                             <div class="je-arr-action-row">
@@ -1280,10 +1288,10 @@
                     </fieldset>
 
                     <fieldset>
-                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">movie</i>Radarr</legend>
+                        <legend class="sectionTitle"><img class="je-legend-icon-img" src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/radarr.svg" alt="">Radarr</legend>
                         <div class="configSection">
                             <div class="je-setting-description" data-desc-for="radarrInstancesList">
-                                <div class="fieldDescription">Movie-focused *arr service. Add one instance per Radarr server.</div>
+                                <div class="fieldDescription">Automated movie collection management and monitoring. Add one instance per Radarr server.</div>
                             </div>
                             <div id="radarrInstancesList"></div>
                             <div class="je-arr-action-row">
@@ -1295,10 +1303,10 @@
                     </fieldset>
 
                     <fieldset>
-                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">subtitles</i>Bazarr</legend>
+                        <legend class="sectionTitle"><img class="je-legend-icon-img" src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/bazarr.svg" alt="">Bazarr</legend>
                         <div class="configSection">
                             <div class="je-setting-description" data-desc-for="bazarrUrl">
-                                <div class="fieldDescription">Subtitle-management service. Single instance, no API key — detail-page links only.</div>
+                                <div class="fieldDescription">Automated subtitle downloading and management for Sonarr and Radarr. Single instance, no API key — detail-page links only.</div>
                             </div>
 
                             <div class="inputContainer">
@@ -1438,22 +1446,20 @@
                                         <div class="fieldDescription"><br/>Shared with Seerr Settings</div>
                                     </div>
 
-                            <div style="display:flex; gap:15px; flex-wrap:wrap;">
-                                <div class="inputContainer" style="flex:1;">
+                                <div class="inputContainer">
                                     <label class="inputLabel" for="DEFAULT_REGION">Default Region</label>
                                     <input id="DEFAULT_REGION" is="emby-input" type="text" placeholder="e.g., US"/>
                                 </div>
                                     <div class="je-setting-description" data-desc-for="DEFAULT_REGION">
                                         <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt" target="_blank">Full List</a></div>
                                     </div>
-                                <div class="inputContainer" style="flex:2;">
+                                <div class="inputContainer">
                                     <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>
                                     <input id="DEFAULT_PROVIDERS" class="emby-input" type="text" placeholder="e.g., Netflix,Hulu"/>
                                 </div>
                                     <div class="je-setting-description" data-desc-for="DEFAULT_PROVIDERS">
                                         <div class="fieldDescription">A list of default streaming providers to show. Leave blank to show all. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt" target="_blank">Full List</a></div>
                                     </div>
-                            </div>
                             <div class="inputContainer">
                                 <label class="inputLabel" for="IGNORE_PROVIDERS">Ignore Providers</label>
                                 <input id="IGNORE_PROVIDERS" class="emby-input" type="text" placeholder="e.g., .*with Ads, Hulu"/>
@@ -2630,6 +2636,7 @@
         var hasPluginPages = null;
         var hasCustomTabs = null;
         var hasIntroSkipper = null;
+        var hasInPlayerEpisodePreview = null;
         var hasFileTransformation = null;
         var hasKefinTweaks = null;
         var _jeDisabledPlugins = {}; // key -> true when installed but Status !== 'Active'
@@ -2696,6 +2703,7 @@
                 hasPluginPages        = probe('pluginPages',        ['Plugin Pages']);
                 hasCustomTabs         = probe('customTabs',         ['Custom Tabs']);
                 hasIntroSkipper       = probe('introSkipper',       ['Intro Skipper', 'SkipIntro']);
+                hasInPlayerEpisodePreview = probe('inPlayerEpisodePreview', ['In Player Episode Preview', 'InPlayerEpisodePreview']);
 
                 // KefinTweaks installs as a web-mod (files in /config/KefinTweaks/
                 // injected via File Transformation into index.html), NOT as a
@@ -2720,6 +2728,7 @@
                 document.body.classList.toggle('je-has-customtabs',        hasCustomTabs         === true);
                 document.body.classList.toggle('je-has-pluginpages',       hasPluginPages        === true);
                 document.body.classList.toggle('je-has-introskipper',      hasIntroSkipper       === true);
+                document.body.classList.toggle('je-has-inplayerepisodepreview', hasInPlayerEpisodePreview === true);
                 document.body.classList.toggle('je-has-kefintweaks',       hasKefinTweaks        === true);
                 document.body.classList.toggle('je-has-filetransformation', hasFileTransformation === true);
 
@@ -2757,10 +2766,11 @@
                 hasPluginPages = null;
                 hasCustomTabs = null;
                 hasIntroSkipper = null;
+                hasInPlayerEpisodePreview = null;
                 hasFileTransformation = null;
                 hasKefinTweaks = null;
                 customTabsCompatState = null;
-                document.body.classList.remove('je-has-customtabs', 'je-has-pluginpages', 'je-has-introskipper', 'je-has-customtabs-compat', 'je-has-kefintweaks', 'je-has-filetransformation');
+                document.body.classList.remove('je-has-customtabs', 'je-has-pluginpages', 'je-has-introskipper', 'je-has-inplayerepisodepreview', 'je-has-customtabs-compat', 'je-has-kefintweaks', 'je-has-filetransformation');
                 setProbeWarning('plugins', "Couldn't reach the Jellyfin /Plugins endpoint to verify which integrations are installed (auth expiry, network, or server issue). Dependency hints and \"plugin detected\" badges are now hidden until you retry.");
                 try { updateAllDependencies(); } catch (e) {
                     console.warn('[JE] updateAllDependencies threw during plugin-detect fallback:', e);
@@ -4482,6 +4492,48 @@
             });
         })();
 
+        // Apply the blurred background to .je-sticky-header only when the
+        // scroll container has actually scrolled — at scrollTop=0 the header
+        // stays transparent so it doesn't cover the Jellyfin top bar / user
+        // avatar. The scroll container is whichever ancestor of the form
+        // actually scrolls (usually Jellyfin's page view, occasionally the
+        // window itself on mobile).
+        (function wireStickyHeaderScroll() {
+            var header = document.querySelector('.je-sticky-header');
+            if (!header) return;
+            function findScrollContainer(el) {
+                var node = el && el.parentNode;
+                while (node && node !== document.body && node.nodeType === 1) {
+                    var style = getComputedStyle(node);
+                    var oy = style.overflowY;
+                    if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight) {
+                        return node;
+                    }
+                    node = node.parentNode;
+                }
+                return window;
+            }
+            var container = findScrollContainer(header);
+            var ticking = false;
+            function read() {
+                var top = container === window
+                    ? (window.pageYOffset || document.documentElement.scrollTop || 0)
+                    : container.scrollTop;
+                header.classList.toggle('je-is-scrolled', top > 4);
+                ticking = false;
+            }
+            function onScroll() {
+                if (ticking) return;
+                ticking = true;
+                requestAnimationFrame(read);
+            }
+            container.addEventListener('scroll', onScroll, { passive: true });
+            // Prior listeners from a previous pageshow may still be live —
+            // removeEventListener is a no-op when none match, and idempotent
+            // when one does, so re-adding is safe across SPA re-entries.
+            read();
+        })();
+
         // ================================
         // SETTING DEPENDENCY SYSTEM
         // ================================
@@ -5043,6 +5095,7 @@
             { key: 'pluginPages',        name: 'Plugin Pages',        icon: 'view_list',       url: 'https://github.com/IAmParadox27/jellyfin-plugin-pages',               purpose: 'Sidebar pages for Bookmarks, Hidden Content, Requests, Calendar.',                   getFlag: function(){ return hasPluginPages; } },
             { key: 'customTabs',         name: 'Custom Tabs',         icon: 'tab',             url: 'https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs',         purpose: 'Home-page tab entries for Bookmarks, Hidden Content, Requests, Calendar.',          getFlag: function(){ return hasCustomTabs; } },
             { key: 'introSkipper',       name: 'Intro Skipper',       icon: 'skip_next',       url: 'https://github.com/intro-skipper/intro-skipper',                      purpose: 'Source of timestamps for Auto-skip Intro / Auto-skip Outro.',                        getFlag: function(){ return hasIntroSkipper; } },
+            { key: 'inPlayerEpisodePreview', name: 'In-Player Episode Preview', icon: 'movie_filter', url: 'https://github.com/Namo2/InPlayerEpisodePreview',            purpose: 'Enables the in-player Episode Preview keyboard shortcut.',                           getFlag: function(){ return hasInPlayerEpisodePreview; } },
             { key: 'kefinTweaks',        name: 'KefinTweaks',         icon: 'bookmark_border', url: 'https://github.com/ranaldsgift/KefinTweaks',                          purpose: 'Renders the Watchlist UI in Jellyfin. Required to view watchlisted items from the Seerr Watchlist features. Installs as a web-mod (not a normal plugin), detected via its injected scripts.', getFlag: function(){ return hasKefinTweaks; } }
         ];
         function renderOptionalPluginsDashboard() {
@@ -5527,7 +5580,8 @@
             pushCard({
                 id: 'tmdb',
                 name: 'TMDB',
-                tab: 'extras',
+                tab: 'elsewhere',
+                scrollTo: '#TMDB_API_KEY',
                 state: tmdbKey ? 'ok' : 'off',
                 detail: tmdbKey ? 'API key set' : 'No API key',
                 icon: 'vpn_key'
@@ -5661,6 +5715,16 @@
                 btn.addEventListener('click', function() {
                     var tabBtn = document.querySelector('.jellyfin-tab-button[data-tab="' + c.tab + '"]');
                     if (tabBtn) tabBtn.click();
+                    // Optional deep-link: after the tab activates (next frame so
+                    // content has laid out), scroll the specific field into
+                    // view. Cards that don't set scrollTo land at the tab's
+                    // scroll-memory position as before.
+                    if (c.scrollTo) {
+                        requestAnimationFrame(function() {
+                            var target = document.querySelector(c.scrollTo);
+                            if (target) target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        });
+                    }
                 });
                 root.appendChild(btn);
             });

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -2195,6 +2195,18 @@
                     parent.replaceChild(document.createTextNode(mark.textContent), mark);
                     parent.normalize();
                 });
+                // Unwrap the flex/grid protection spans added by
+                // highlightTextIn. After the marks above were unwrapped,
+                // the wrapper contains only text nodes — move them up to
+                // the parent and drop the wrapper, so normalize() can
+                // merge back into a single text node identical to before
+                // the search.
+                form.querySelectorAll('.je-search-wrap').forEach(wrap => {
+                    const parent = wrap.parentNode;
+                    while (wrap.firstChild) parent.insertBefore(wrap.firstChild, wrap);
+                    parent.removeChild(wrap);
+                    parent.normalize();
+                });
                 allMatches = [];
                 currentMatchIdx = -1;
             }
@@ -2233,7 +2245,27 @@
                         last = idx + query.length;
                     }
                     if (last < text.length) frag.appendChild(document.createTextNode(text.substring(last)));
-                    node.parentNode.replaceChild(frag, node);
+
+                    // If the text node lives directly inside a flex/grid
+                    // container, splitting it into mark + remainder nodes
+                    // creates multiple flex/grid items. Those items then
+                    // get repositioned by justify-content / align-items on
+                    // the parent — e.g. a <summary> with space-between
+                    // would spread the <mark> to the start and the
+                    // trailing text to the end, splitting "Auto Season
+                    // Requests" into "Auto Sea" ... "son Requests" on a
+                    // search for "auto sea". Wrap in an inline span so
+                    // the parent still sees a single child.
+                    var parent = node.parentNode;
+                    var parentDisplay = getComputedStyle(parent).display;
+                    if (/(flex|grid)$/.test(parentDisplay) && frag.childNodes.length > 1) {
+                        var wrapper = document.createElement('span');
+                        wrapper.className = 'je-search-wrap';
+                        wrapper.appendChild(frag);
+                        parent.replaceChild(wrapper, node);
+                    } else {
+                        parent.replaceChild(frag, node);
+                    }
                 });
             }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1425,7 +1425,7 @@
                 </div>
 
                 <div id="elsewhere" class="jellyfin-tab-content">
-                    <fieldset class="je-fieldset-wide">
+                    <fieldset>
                         <legend class="sectionTitle">Elsewhere (Streaming Providers)</legend>
                         <div class="configSection">
                             <div class="checkboxContainer"><label><input id="elsewhereEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Elsewhere</span></label></div>
@@ -1490,7 +1490,7 @@
                         </div>
                     </fieldset>
 
-                    <fieldset class="je-fieldset-wide">
+                    <fieldset>
                         <legend class="sectionTitle">Reviews</legend>
                         <div class="configSection">
                             <div class="checkboxContainer"><label><input id="showReviews" is="emby-checkbox" type="checkbox"/><span>Show TMDB Reviews</span></label></div>

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1446,26 +1446,20 @@
                                         <div class="fieldDescription"><br/>Shared with Seerr Settings</div>
                                     </div>
 
-                                <div class="je-two-col-pairs">
-                                    <div class="je-two-col-pair">
-                                        <div class="inputContainer">
-                                            <label class="inputLabel" for="DEFAULT_REGION">Default Region</label>
-                                            <input id="DEFAULT_REGION" is="emby-input" type="text" placeholder="e.g., US"/>
-                                        </div>
-                                        <div class="je-setting-description" data-desc-for="DEFAULT_REGION">
-                                            <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt" target="_blank">Full List</a></div>
-                                        </div>
-                                    </div>
-                                    <div class="je-two-col-pair">
-                                        <div class="inputContainer">
-                                            <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>
-                                            <input id="DEFAULT_PROVIDERS" class="emby-input" type="text" placeholder="e.g., Netflix,Hulu"/>
-                                        </div>
-                                        <div class="je-setting-description" data-desc-for="DEFAULT_PROVIDERS">
-                                            <div class="fieldDescription">A list of default streaming providers to show. Leave blank to show all. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt" target="_blank">Full List</a></div>
-                                        </div>
-                                    </div>
+                                <div class="inputContainer">
+                                    <label class="inputLabel" for="DEFAULT_REGION">Default Region</label>
+                                    <input id="DEFAULT_REGION" is="emby-input" type="text" placeholder="e.g., US"/>
                                 </div>
+                                    <div class="je-setting-description" data-desc-for="DEFAULT_REGION">
+                                        <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt" target="_blank">Full List</a></div>
+                                    </div>
+                                <div class="inputContainer">
+                                    <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>
+                                    <input id="DEFAULT_PROVIDERS" class="emby-input" type="text" placeholder="e.g., Netflix,Hulu"/>
+                                </div>
+                                    <div class="je-setting-description" data-desc-for="DEFAULT_PROVIDERS">
+                                        <div class="fieldDescription">A list of default streaming providers to show. Leave blank to show all. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt" target="_blank">Full List</a></div>
+                                    </div>
                             <div class="inputContainer">
                                 <label class="inputLabel" for="IGNORE_PROVIDERS">Ignore Providers</label>
                                 <input id="IGNORE_PROVIDERS" class="emby-input" type="text" placeholder="e.g., .*with Ads, Hulu"/>

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -14,12 +14,11 @@
                     <div class="je-header-title-row">
                         <h2 class="sectionTitle">Jellyfin Enhanced</h2>
                         <a is="emby-linkbutton" class="raised raised-mini emby-button je-help-link" target="_blank" href="https://github.com/n00bcodr/Jellyfin-Enhanced" title="Docs &amp; Help" aria-label="Docs and Help">
-                            <i class="material-icons button-icon button-icon-left secondaryText" aria-hidden="true">help_outline</i>
                             <span class="je-help-link-label">Docs &amp; Help</span>
                         </a>
                         <button id="toggleDescriptionsBtn" type="button" class="raised raised-mini emby-button je-desc-toggle" title="Show or hide setting descriptions" aria-label="Show or hide setting descriptions" aria-pressed="true">
-                            <i class="material-icons button-icon button-icon-left secondaryText" aria-hidden="true">subject</i>
                             <span class="je-desc-toggle-label">Descriptions</span>
+                            <span class="je-desc-toggle-state" aria-hidden="true">On</span>
                         </button>
                     </div>
                     <div id="settingsSearchContainer">
@@ -2100,8 +2099,11 @@
                 if (descToggleBtn) {
                     descToggleBtn.setAttribute('aria-pressed', show ? 'true' : 'false');
                     descToggleBtn.classList.toggle('je-desc-toggle-off', !show);
-                    const label = descToggleBtn.querySelector('.je-desc-toggle-label');
-                    if (label) label.textContent = show ? 'Descriptions' : 'Descriptions off';
+                    // Label stays "Descriptions" regardless of state; the
+                    // adjacent pill (.je-desc-toggle-state) carries the
+                    // On/Off indicator.
+                    const state = descToggleBtn.querySelector('.je-desc-toggle-state');
+                    if (state) state.textContent = show ? 'On' : 'Off';
                 }
             }
             (function initDescriptionVisibility() {

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1446,20 +1446,26 @@
                                         <div class="fieldDescription"><br/>Shared with Seerr Settings</div>
                                     </div>
 
-                                <div class="inputContainer">
-                                    <label class="inputLabel" for="DEFAULT_REGION">Default Region</label>
-                                    <input id="DEFAULT_REGION" is="emby-input" type="text" placeholder="e.g., US"/>
-                                </div>
-                                    <div class="je-setting-description" data-desc-for="DEFAULT_REGION">
-                                        <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt" target="_blank">Full List</a></div>
+                                <div class="je-two-col-pairs">
+                                    <div class="je-two-col-pair">
+                                        <div class="inputContainer">
+                                            <label class="inputLabel" for="DEFAULT_REGION">Default Region</label>
+                                            <input id="DEFAULT_REGION" is="emby-input" type="text" placeholder="e.g., US"/>
+                                        </div>
+                                        <div class="je-setting-description" data-desc-for="DEFAULT_REGION">
+                                            <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt" target="_blank">Full List</a></div>
+                                        </div>
                                     </div>
-                                <div class="inputContainer">
-                                    <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>
-                                    <input id="DEFAULT_PROVIDERS" class="emby-input" type="text" placeholder="e.g., Netflix,Hulu"/>
-                                </div>
-                                    <div class="je-setting-description" data-desc-for="DEFAULT_PROVIDERS">
-                                        <div class="fieldDescription">A list of default streaming providers to show. Leave blank to show all. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt" target="_blank">Full List</a></div>
+                                    <div class="je-two-col-pair">
+                                        <div class="inputContainer">
+                                            <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>
+                                            <input id="DEFAULT_PROVIDERS" class="emby-input" type="text" placeholder="e.g., Netflix,Hulu"/>
+                                        </div>
+                                        <div class="je-setting-description" data-desc-for="DEFAULT_PROVIDERS">
+                                            <div class="fieldDescription">A list of default streaming providers to show. Leave blank to show all. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt" target="_blank">Full List</a></div>
+                                        </div>
                                     </div>
+                                </div>
                             <div class="inputContainer">
                                 <label class="inputLabel" for="IGNORE_PROVIDERS">Ignore Providers</label>
                                 <input id="IGNORE_PROVIDERS" class="emby-input" type="text" placeholder="e.g., .*with Ads, Hulu"/>

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -2306,6 +2306,7 @@
             function enterSearchMode() {
                 if (isSearchMode) return;
                 isSearchMode = true;
+                form.classList.add('je-search-mode');
                 form.querySelectorAll('details').forEach(d => {
                     savedDetailsStates.set(d, d.open);
                 });
@@ -2336,6 +2337,8 @@
              */
             function exitSearchMode() {
                 isSearchMode = false;
+                form.classList.remove('je-search-mode');
+                form.querySelectorAll('.je-tab-name-match').forEach(tc => tc.classList.remove('je-tab-name-match'));
                 clearHighlights();
                 form.querySelectorAll('.je-search-tab-label').forEach(el => el.remove());
                 if (tabButtonsContainer) tabButtonsContainer.style.display = '';
@@ -2428,6 +2431,22 @@
                     });
 
                     tabContent.style.display = tabHasMatch ? 'block' : 'none';
+
+                    // Rank tab-contents whose tab button's label itself
+                    // contains the query above tabs that matched only by
+                    // buried content. Searching "elsewhere" now surfaces
+                    // the Elsewhere tab first even though other tabs
+                    // (Overview service-status, Seerr) reference it too.
+                    // The CSS .je-tab-name-match rule (flex order: -1)
+                    // does the actual reordering in the form container.
+                    const btn = document.querySelector('.jellyfin-tab-button[data-tab="' + tabContent.id + '"]');
+                    let tabLabel = tabContent.id.toLowerCase();
+                    if (btn) {
+                        const clone = btn.cloneNode(true);
+                        clone.querySelectorAll('i.material-icons, img').forEach(el => el.remove());
+                        tabLabel = clone.textContent.trim().toLowerCase();
+                    }
+                    tabContent.classList.toggle('je-tab-name-match', tabHasMatch && tabLabel.includes(query));
                 });
 
                 allMatches = Array.from(form.querySelectorAll('.je-search-match'));

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -8,346 +8,477 @@
     <link rel="stylesheet" href="/JellyfinEnhanced/Configuration/configPage.css">
     <div data-role="content">
         <div class="content-primary">
-            <div class="verticalSection">
+
+            <div class="je-sticky-header">
                 <div class="sectionTitleContainer">
-                     <h2 class="sectionTitle">Jellyfin Enhanced</h2>
-                        <a is="emby-linkbutton" class="raised raised-mini emby-button je-help-link" target="_blank" href="https://github.com/n00bcodr/Jellyfin-Enhanced">
-                            <i class="md-icon button-icon button-icon-left secondaryText"></i>
-                            <span>Help</span>
+                    <div class="je-header-title-row">
+                        <h2 class="sectionTitle">Jellyfin Enhanced</h2>
+                        <a is="emby-linkbutton" class="raised raised-mini emby-button je-help-link" target="_blank" href="https://github.com/n00bcodr/Jellyfin-Enhanced" title="Docs &amp; Help" aria-label="Docs and Help">
+                            <i class="material-icons button-icon button-icon-left secondaryText" aria-hidden="true">help_outline</i>
+                            <span class="je-help-link-label">Docs &amp; Help</span>
                         </a>
-                                <div id="settingsSearchContainer">
-                                    <div>
-                                        <i class="material-icons je-search-icon">search</i>
-                                        <input id="settingsSearchInput" type="text" placeholder="Search settings..." />
-                                        <span id="settingsSearchCount"></span>
-                                        <button id="settingsSearchClear" type="button">&#x2715;</button>
-                                    </div>
-                                </div>
+                        <button id="toggleDescriptionsBtn" type="button" class="raised raised-mini emby-button je-desc-toggle" title="Show or hide setting descriptions" aria-label="Show or hide setting descriptions" aria-pressed="true">
+                            <i class="material-icons button-icon button-icon-left secondaryText" aria-hidden="true">subject</i>
+                            <span class="je-desc-toggle-label">Descriptions</span>
+                        </button>
+                    </div>
+                    <div id="settingsSearchContainer">
+                        <div>
+                            <i class="material-icons je-search-icon">search</i>
+                            <input id="settingsSearchInput" type="text" placeholder="Search settings..." />
+                            <span id="settingsSearchCount"></span>
+                            <button id="settingsSearchClear" type="button" title="Clear search">&#x2715;</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="je-tab-bar">
+                <button class="jellyfin-tab-button active" data-tab="overview"><h3><i class="material-icons je-tab-icon" aria-hidden="true">dashboard</i>Overview</h3></button>
+                <button class="jellyfin-tab-button" data-tab="display"><h3><i class="material-icons je-tab-icon" aria-hidden="true">palette</i>Display</h3></button>
+                <button class="jellyfin-tab-button" data-tab="playback"><h3><i class="material-icons je-tab-icon" aria-hidden="true">play_circle</i>Playback</h3></button>
+                <button class="jellyfin-tab-button" data-tab="pages"><h3><i class="material-icons je-tab-icon" aria-hidden="true">view_list</i>Pages</h3></button>
+                <button class="jellyfin-tab-button" data-tab="seerr"><h3><img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/seerr.svg" alt="" class="je-tab-icon-img">Seerr</h3></button>
+                <button class="jellyfin-tab-button" data-tab="arr"><h3><i class="material-icons je-tab-icon" aria-hidden="true">dns</i>*arr</h3></button>
+                <button class="jellyfin-tab-button" data-tab="elsewhere"><h3><i class="material-icons je-tab-icon" aria-hidden="true">travel_explore</i>Elsewhere</h3></button>
+                <button class="jellyfin-tab-button" data-tab="extras"><h3><i class="material-icons je-tab-icon" aria-hidden="true">auto_awesome</i>Extras</h3></button>
+                    <button class="jellyfin-tab-button" data-tab="keyboard"><h3><i class="material-icons je-tab-icon" aria-hidden="true">keyboard</i>Keyboard</h3></button>
+                    <button class="jellyfin-tab-button" data-tab="docs"><h3><i class="material-icons je-tab-icon" aria-hidden="true">menu_book</i>Docs</h3></button>
                 </div>
             </div>
-            <hr>
 
-            <div id="fileTransformationWarning" style="display: none;">
-                <strong class="je-ft-warning-title">⚠️ Highly Recommended</strong><br>
-                It is highly recommended to have the <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" class="je-ft-warning-link">File Transformation</a> plugin installed. It helps avoid permission issues while modifying <code class="je-ft-warning-code">index.html</code> on any kind of installation.
-                <a href="https://github.com/n00bcodr/Jellyfin-Enhanced?tab=readme-ov-file#-installation" target="_blank" class="je-ft-warning-link">Learn more</a>
-                <div class="je-ft-warning-actions">
-                    <button id="dismissFtWarningSession" type="button" class="je-ft-warning-btn">Dismiss</button>
-                    <button id="dismissFtWarningForever" type="button" class="je-ft-warning-btn">Don't show again</button>
+            <div id="je-probe-warning" class="je-note-banner" style="display: none;" role="status" aria-live="polite">
+                <i class="material-icons je-note-icon">warning_amber</i>
+                <div>
+                    <strong>Plugin detection issue</strong>
+                    <span id="je-probe-warning-msg"></span>
+                    <div style="margin-top:8px;">
+                        <button id="je-probe-retry-btn" type="button" class="emby-button raised raised-mini">Retry</button>
+                    </div>
                 </div>
             </div>
 
-            <div class="je-tab-bar">
-                <button class="jellyfin-tab-button active" data-tab="enhanced"><h3>Enhanced Settings</h3></button>
-                <button class="jellyfin-tab-button" data-tab="elsewhere"><h3>Elsewhere Settings</h3></button>
-                <button class="jellyfin-tab-button" data-tab="jellyseerr"><h3><img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/seerr.svg" alt="Seerr">Seerr Settings</h3></button>
-                <button class="jellyfin-tab-button" data-tab="arr-links"><h3>*arr Settings</h3></button>
-                <button class="jellyfin-tab-button" data-tab="extras"><h3>Other Settings</h3></button>
+            <div id="fileTransformationWarning" class="je-danger-banner" style="display: none;">
+                <i class="material-icons je-danger-icon">error_outline</i>
+                <div>
+                    <strong class="je-ft-warning-title">Highly Recommended: File Transformation Plugin</strong><br>
+                    It is highly recommended to have the <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" class="je-ft-warning-link">File Transformation</a> plugin installed. It helps avoid permission issues while modifying <code class="je-ft-warning-code">index.html</code>.
+                    <a href="https://github.com/n00bcodr/Jellyfin-Enhanced?tab=readme-ov-file#-installation" target="_blank" class="je-ft-warning-link">Learn more</a>
+                    <div class="je-ft-warning-actions">
+                        <button id="dismissFtWarningSession" type="button" class="emby-button raised raised-mini">Dismiss</button>
+                        <button id="dismissFtWarningForever" type="button" class="emby-button raised raised-mini">Don't show again</button>
+                    </div>
+                </div>
             </div>
+
             <form id="JellyfinEnhancedForm">
-                <div id="enhanced" class="jellyfin-tab-content active">
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Default User Settings</h3></legend>
-                        <div class="configSection">
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary" data-icon="playback" data-text="Playback Settings">⏯️ Playback Settings</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer"><label><input id="autoPauseEnabled" is="emby-checkbox" type="checkbox"/><span>Auto-pause on tab switch</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="autoResumeEnabled" is="emby-checkbox" type="checkbox"/><span>Auto-resume on tab switch</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="autoPipEnabled" is="emby-checkbox" type="checkbox"/><span>Auto Picture-in-Picture on tab switch</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="longPress2xEnabled" is="emby-checkbox" type="checkbox"/><span>Long press/hold for 2x speed <sup> β</sup></span></label></div>
-                                    <div class="checkboxContainer"><label><input id="pauseScreenEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Custom Pause Screen</span></label></div>
-                                    <div class="fieldDescription je-field-desc-sm">This feature is a modified version of the original script by <a class="sectionTitle" target="_blank" href="https://github.com/BobHasNoSoul/Jellyfin-PauseScreen">BobHasNoSoul</a></div>
-                                </div>
-                            </details>
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary" data-icon="skip" data-text="Auto-Skip Settings">↪️ Auto-Skip Settings</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer"><label><input id="autoSkipIntro" is="emby-checkbox" type="checkbox"/><span>Auto-skip Intro</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="autoSkipOutro" is="emby-checkbox" type="checkbox"/><span>Auto-skip Outro</span></label></div>
-                                </div>
-                            </details>
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary" data-icon="subtitles" data-text="Subtitle Settings">📝 Subtitle Settings</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer je-checkbox-mb-1"><label><input id="disableCustomSubtitleStyles" is="emby-checkbox" type="checkbox"/><span>Disable Custom Subtitle Styles by default</span></label></div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="DefaultSubtitleStyle">Default Subtitle Style</label>
-                                        <select is="emby-select" id="DefaultSubtitleStyle" name="DefaultSubtitleStyle" class="emby-select">
-                                            <option value="0">Clean White</option>
-                                            <option value="1">Classic Black Box</option>
-                                            <option value="2">Netflix Style</option>
-                                            <option value="3">Cinema Yellow</option>
-                                            <option value="4">Soft Gray</option>
-                                            <option value="5">High Contrast</option>
-                                        </select>
-                                    </div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="DefaultSubtitleSize">Default Subtitle Size</label>
-                                        <select is="emby-select" id="DefaultSubtitleSize" name="DefaultSubtitleSize" class="emby-select">
-                                            <option value="0">Tiny</option>
-                                            <option value="1">Small</option>
-                                            <option value="2">Normal</option>
-                                            <option value="3">Large</option>
-                                            <option value="4">Extra Large</option>
-                                            <option value="5">Gigantic</option>
-                                        </select>
-                                    </div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="DefaultSubtitleFont">Default Subtitle Font</label>
-                                        <select is="emby-select" id="DefaultSubtitleFont" name="DefaultSubtitleFont" class="emby-select">
-                                            <option value="0">Default</option>
-                                            <option value="1">Noto Sans</option>
-                                            <option value="2">Sans Serif</option>
-                                            <option value="3">Typewriter</option>
-                                            <option value="4">Roboto</option>
-                                        </select>
-                                    </div>
-                                </div>
-                            </details>
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary" data-icon="random" data-text="Random Button Settings">🎲 Random Button Settings</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer"><label><input id="randomButtonEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Random Button</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="randomUnwatchedOnly" is="emby-checkbox" type="checkbox"/><span>Show unwatched only in random selection</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="randomIncludeMovies" is="emby-checkbox" type="checkbox"/><span>Include movies in random selection</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="randomIncludeShows" is="emby-checkbox" type="checkbox"/><span>Include shows in random selection</span></label></div>
-                                </div>
-                            </details>
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary" data-icon="ui" data-text="UI Settings">🖥️ UI Settings</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer"><label><input id="showWatchProgress" is="emby-checkbox" type="checkbox"/><span>Show watch progress</span></label></div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="watchProgressDefaultMode">Watch Progress Default</label>
-                                        <select is="emby-select" id="watchProgressDefaultMode" name="watchProgressDefaultMode" class="emby-select">
-                                            <option value="percentage">Percentage</option>
-                                            <option value="time">Time Watched</option>
-                                            <option value="remaining">Time Remaining</option>
-                                        </select>
-                                        <div class="fieldDescription">Choose default display for watch progress.</div>
-                                    </div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="watchProgressTimeFormat">Watch Progress Time Format</label>
-                                        <select is="emby-select" id="watchProgressTimeFormat" name="watchProgressTimeFormat" class="emby-select">
-                                            <option value="hours">h:m</option>
-                                            <option value="full">y:mo:d:h:m</option>
-                                        </select>
-                                        <div class="fieldDescription">Select how time-based progress is shown.</div>
-                                    </div>
-                                    <div class="checkboxContainer"><label><input id="showFileSizes" is="emby-checkbox" type="checkbox"/><span>Show file sizes</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="showAudioLanguages" is="emby-checkbox" type="checkbox"/><span>Show available audio languages on item detail page</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="removeContinueWatchingEnabled" is="emby-checkbox" type="checkbox"/><span>Enable "Remove from Continue Watching"</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="qualityTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Quality Tags</span></label></div>
-                                    <div class="fieldDescription je-field-desc-sm">This feature is a slightly modified version of the original script by <a class="sectionTitle" target="_blank" href="https://github.com/BobHasNoSoul/Jellyfin-Qualitytags/">BobHasNoSoul</a></div>
-                                    <div class="checkboxContainer"><label><input id="genreTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Genre Tags</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="languageTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Language Tags</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="ratingTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Rating Tags</span></label></div>
-                                    <div class="checkboxContainer"><label><input id="peopleTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable People Tags</span></label></div>
 
-                                    <fieldset class="je-tags-fieldset">
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="qualityTagsPosition">Quality Tags Position</label>
-                                        <select is="emby-select" id="qualityTagsPosition" name="qualityTagsPosition" class="emby-select">
-                                            <option value="top-left">Top Left</option>
-                                            <option value="top-right">Top Right</option>
-                                            <option value="bottom-left">Bottom Left</option>
-                                            <option value="bottom-right">Bottom Right</option>
-                                        </select>
-                                    </div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="genreTagsPosition">Genre Tags Position</label>
-                                        <select is="emby-select" id="genreTagsPosition" name="genreTagsPosition" class="emby-select">
-                                            <option value="top-left">Top Left</option>
-                                            <option value="top-right">Top Right</option>
-                                            <option value="bottom-left">Bottom Left</option>
-                                            <option value="bottom-right">Bottom Right</option>
-                                        </select>
-                                    </div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="languageTagsPosition">Language Tags Position</label>
-                                        <select is="emby-select" id="languageTagsPosition" name="languageTagsPosition" class="emby-select">
-                                            <option value="top-left">Top Left</option>
-                                            <option value="top-right">Top Right</option>
-                                            <option value="bottom-left">Bottom Left</option>
-                                            <option value="bottom-right">Bottom Right</option>
-                                        </select>
-                                    </div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="ratingTagsPosition">Rating Tags Position</label>
-                                        <select is="emby-select" id="ratingTagsPosition" name="ratingTagsPosition" class="emby-select">
-                                            <option value="top-left">Top Left</option>
-                                            <option value="top-right">Top Right</option>
-                                            <option value="bottom-left">Bottom Left</option>
-                                            <option value="bottom-right">Bottom Right</option>
-                                        </select>
-                                    </div>
-                                    <div class="inputContainer je-input-mt">
-                                        <label class="inputLabel inputLabelUnfocused" for="tagsCacheTtlDays">Tags Cache Duration (days)</label>
-                                        <input id="tagsCacheTtlDays" is="emby-input" type="number" min="1" max="365" value="30"/>
-                                        <div class="fieldDescription">How long to cache the above tags data (1-365 days, default: 30)</div>
-                                    </div>
-                                     <div class="checkboxContainer je-checkbox-mt">
-                                        <label class="je-rating-label"><input id="showRatingInPlayer" is="emby-checkbox" type="checkbox"/>
-                                            <span>
-                                                Show Rating in Video Player
-                                            <div>Display TMDB and Rotten Tomatoes ratings before "Ends at" time in video player</div>
-                                            </span>
-                                        </label>
-                                    </div>
-                                    <div id="clientTagCacheControls" class="je-input-mt">
-                                        <button id="clearTagsCacheBtn" class="raised button-submit emby-button" is="emby-button" type="button">
-                                            <span>Clear All Client Caches</span>
-                                        </button>
-                                        <div class="fieldDescription">Forces all clients to clear Language, Quality, Genre and Rating tag caches on next load<br> After the cache is cleared, the clients will re-fetch the tags data to build the cache again, which might cause some slowness on first load.</div>
-                                    </div>
-                                </fieldset>
-                                <div class="checkboxContainer je-checkbox-mt-2"><label><input id="disableTagsOnSearchPage" is="emby-checkbox" type="checkbox"/><span>Disable Tags on Search Page</span></label></div>
-                                <div class="fieldDescription je-field-desc-sm-font-lg">Prevents quality/language/genre/rating tags from showing on search results. Recommended for compatibility with <b>Gelato</b> plugin.</div>
-                                <div class="checkboxContainer"><label><input id="tagsHideOnHover" is="emby-checkbox" type="checkbox"/><span>Hide Tags on Hover</span></label></div>
-                                <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, tag overlays fade out when users hover over cards. Users can override this in their personal settings.</div>
-                                <div class="checkboxContainer"><label><input id="tagCacheServerMode" is="emby-checkbox" type="checkbox"/><span>Server-Side Tag Cache</span></label></div>
-                                <div class="fieldDescription je-field-desc-sm-font-lg">Pre-computes tag data on the server and serves it in a single request. Tags load instantly without per-page API calls. Disable to use the legacy per-page batch mode (not recommended).</div>
-                                <div id="tagsLocalStorageFallbackContainer" class="checkboxContainer"><label><input id="enableTagsLocalStorageFallback" is="emby-checkbox" type="checkbox"/><span>Persist Tag Fallback Cache in Browser Local Storage</span></label></div>
-                                <div class="fieldDescription je-field-desc-sm-font-xl">Available when Server-Side Tag Cache is disabled. Stores fallback tag cache entries in browser localStorage for faster repeat loads.</div>
-                            </div>
-                        </details>
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary" data-icon="language" data-text="Language Settings">🌐 Language Settings</summary>
-                                <div class="je-details-body">
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="DefaultLanguage">Default UI Language</label>
-                                        <select is="emby-select" id="DefaultLanguage" name="DefaultLanguage" class="emby-select">
-                                            <option value="">System Default</option>
-                                        </select>
-                                        <div class="fieldDescription">Sets the default language for all users. Users can still override this in their own settings.</div>
-                                    </div>
-                                </div>
-                            </details>
-                            <div class="je-details-body">
-                                    <div class="checkboxContainer"><label><input id="disableAllShortcuts" is="emby-checkbox" type="checkbox"/><span data-icon="keyboard" data-text="Disable Keyboard Shortcuts">⌨️ Disable Keyboard Shortcuts</span></label></div>
-                                    <div class="fieldDescription">Disables all keyboard shortcuts, and hides the 'Shortcuts' tab in enhanced panel</div>
-                                </div>
+                <div id="overview" class="jellyfin-tab-content active">
+                    <div class="je-info-banner je-fieldset-wide je-overview-intro">
+                        <i class="material-icons je-info-icon">dashboard</i>
+                        <div>
+                            The essential enhancement suite for Jellyfin, bundling advanced features and customizations into one convenient plugin.<br/><br/>
+                            This <strong>Overview</strong> is a read-only snapshot: service connection health, which optional companion plugins are installed, and which features are currently enabled or misconfigured. <em>To turn features on or off, use the other tabs above</em> (Display, Playback, Pages, Seerr, *arr, Extras, …). Clicking any card here jumps straight to the tab that owns it.
                         </div>
-                        <div class="verticalSection je-apply-section">
-                            <button id="resetAllUserSettingsBtn" class="raised button-submit block emby-button" is="emby-button" type="button">
-                                <span>Apply Above Settings to All Users</span>
-                            </button>
-                            <div class="je-info-banner">
-                                <div class="je-info-banner-row">
-                                    <i class="material-icons je-info-icon">info</i>
-                                    <div>
-                                        <strong>This will save the current configuration and apply all the above settings to every user on this server.</strong><br>
-                                        <strong>Note:</strong> Users can individually customize their own settings by opening the Enhanced Panel:<br>
-                                        • Press <code>?</code> key (default shortcut)<br>
-                                        • Long Press on user profile picture in the top-right corner<br>
-                                        • Through "Jellyfin Enhanced" link from the side bar<br>
-                                        • Access via playback controls menu during video playback (only on mobile devices)
-                                    </div>
-                                </div>
+                    </div>
+
+                    <fieldset class="je-overview-section">
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">sensors</i>Service Status</legend>
+                        <div class="configSection">
+                            <div class="je-service-dashboard" id="je-service-dashboard">
+                                <div class="je-checklist-empty">Loading service status…</div>
                             </div>
                         </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Icons</h3></legend>
-                        <div class="je-icon-section">
-                            <h4 class="sectionTitle je-section-h4">Icon Settings</h4>
-                                <div class="checkboxContainer">
-                                    <label>
-                                        <input id="useIcons" is="emby-checkbox" type="checkbox"/>
-                                        <span>Use Icons</span>
-                                    </label>
-                                </div>
-                                <div class="fieldDescription je-field-desc-lg">
-                                    Display icons throughout the UI (toasts, settings panel headers, etc.)
-                                </div>
-                                <div class="selectContainer je-select-mb">
-                                    <label class="selectLabel" for="iconStyle">Icon Style</label>
-                                    <select id="iconStyle" is="emby-select" class="emby-select-withcolor">
-                                        <option value="emoji">Emoji</option>
-                                        <option value="lucide">Lucide Icons</option>
-                                        <option value="mui">Material UI Icons</option>
-                                    </select>
-                                    <div class="fieldDescription">Choose between emoji characters, Lucide icons, or Material UI icons.</div>
-                                </div>
+
+                    <fieldset class="je-overview-section" id="overview-optional-plugins-section">
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">extension</i>Optional Dependencies</legend>
+                        <div class="configSection">
+                            <div class="je-optional-plugins-dashboard" id="je-optional-plugins"></div>
+                        </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Shortcut Overrides</h3></legend>
-                        <div class="je-icon-section">
-                            <h4 class="sectionTitle je-section-h4">Add Override</h4>
-                            <div class="je-shortcut-add-row">
-                                <div class="je-shortcut-flex">
-                                    <select is="emby-select" id="add-shortcut-select" label="Shortcut Action"></select>
-                                </div>
-                                <div class="je-shortcut-flex">
-                                    <input is="emby-input" id="add-shortcut-key" type="text" label="New Key"/>
-                                </div>
-                                <button is="emby-button" type="button" id="add-shortcut-btn" class="raised button-submit je-shortcut-add-btn">
-                                    <span>Add</span>
+
+                    <fieldset class="je-overview-section" id="overview-features-section">
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">toggle_on</i>Features</legend>
+                        <div class="configSection">
+                            <div class="je-features-dashboard" id="je-features-dashboard">
+                                <div class="je-checklist-empty">Loading features…</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset class="je-overview-section" id="overview-quick-actions-section">
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">bolt</i>Quick Actions</legend>
+                        <div class="configSection">
+                            <div class="je-quick-actions-grid" id="je-quick-actions-grid">
+                                <button type="button" id="retestAllConnectionsBtn" class="je-quick-action" data-action="retest-all">
+                                    <i class="material-icons je-quick-action-icon" aria-hidden="true">sync</i>
+                                    <div class="je-quick-action-text">
+                                        <span class="je-quick-action-title">Re-test all service connections</span>
+                                        <span class="je-quick-action-detail">Re-runs the TMDB / Seerr / Sonarr / Radarr tests</span>
+                                    </div>
+                                </button>
+                                <button type="button" id="resetAllUserSettingsBtn" class="je-quick-action" data-action="apply-all-users">
+                                    <i class="material-icons je-quick-action-icon" aria-hidden="true">group</i>
+                                    <div class="je-quick-action-text">
+                                        <span class="je-quick-action-title">Apply defaults to all users</span>
+                                        <span class="je-quick-action-detail">Overwrite every user's per-user settings with these defaults</span>
+                                    </div>
+                                </button>
+                                <button type="button" id="clearTagCachesQuickBtn" class="je-quick-action" data-action="clear-tag-caches">
+                                    <i class="material-icons je-quick-action-icon" aria-hidden="true">cleaning_services</i>
+                                    <div class="je-quick-action-text">
+                                        <span class="je-quick-action-title">Clear all client tag caches</span>
+                                        <span class="je-quick-action-detail">Forces every client to rebuild its localStorage tag cache</span>
+                                    </div>
                                 </button>
                             </div>
-                            <div id="shortcut-error-comment" style="display: none;"></div>
-                            <p class="fieldDescription je-field-desc-mt">
-                                <b>Modifier Keys:</b> Use `Shift+`, `Ctrl+`, or `Alt+`. Examples: `Shift+A`, `Ctrl+S`.
-                            </p>
                         </div>
-                        <h4 class="sectionTitle je-section-h4">Configured Overrides</h4>
-                        <div id="shortcut-list-container" class="je-shortcut-list">
-                            </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Bookmarks</h3></legend>
+                </div>
+
+                <div id="display" class="jellyfin-tab-content">
+                    <fieldset>
+                        <legend class="sectionTitle">UI Preferences</legend>
                         <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="bookmarksEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Bookmarks Feature</span>
-                                </label>
+                            <div class="checkboxContainer"><label><input id="showWatchProgress" is="emby-checkbox" type="checkbox"/><span>Show watch progress</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showWatchProgress">
+                                <div class="fieldDescription">Show a progress bar on poster cards for partially-watched items.</div>
                             </div>
-                            <div class="fieldDescription je-field-desc-lg">
-                                Save custom bookmarks/timestamps while watching videos to quickly jump back to your favorite scenes or moments.
+
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="watchProgressDefaultMode">Watch Progress Default</label>
+                                <select is="emby-select" id="watchProgressDefaultMode" name="watchProgressDefaultMode" class="emby-select">
+                                    <option value="percentage">Percentage</option>
+                                    <option value="time">Time Watched</option>
+                                    <option value="remaining">Time Remaining</option>
+                                </select>
                             </div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="bookmarksUsePluginPages" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Plugin Pages for Bookmarks Library</span>
-                                </label>
+                            <div class="je-setting-description" data-desc-for="watchProgressDefaultMode">
+                                <div class="fieldDescription">Choose default display for watch progress (percentage, time watched, or time remaining).</div>
                             </div>
-                            <div class="fieldDescription je-field-desc-xl">Adds a "Bookmarks" link to the sidebar via <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-pages">Plugin Pages</a>.<br><strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="bookmarksUseCustomTabs" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Custom Tabs for Bookmarks (instead of sidebar)</span>
-                                </label>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="watchProgressTimeFormat">Watch Progress Time Format</label>
+                                <select is="emby-select" id="watchProgressTimeFormat" name="watchProgressTimeFormat" class="emby-select">
+                                    <option value="hours">h:m</option>
+                                    <option value="full">y:mo:d:h:m</option>
+                                </select>
                             </div>
-                            <div class="je-info-banner-inline">
-                                <div class="je-info-banner-row">
-                                    <i class="material-icons je-info-icon">info</i>
-                                    <div>
-                                        <h4 class="je-custom-tabs-h4">Embed Bookmarks in Custom Tabs:</h4>
-                                        <p class="fieldDescription je-custom-tabs-p">Display the Bookmarks library in a Custom Tabs tab instead of the sidebar link.</p>
-                                        <p class="fieldDescription je-custom-tabs-p-mt">You need the <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs">Custom Tabs</a> plugin.</p>
-                                        <ol class="fieldDescription je-custom-tabs-ol">
-                                            <li class="je-custom-tabs-li">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
-                                            <li class="je-custom-tabs-li">Navigate to Dashboard > Plugins > Custom Tabs and add a new tab.</li>
-                                            <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Bookmarks").</li>
-                                            <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
-                                        </ol>
-                                        <div class="je-copy-code-wrapper">
-                                            <button type="button" class="je-copy-html-btn raised raised-mini emby-button" data-copy-text="&lt;div class=&quot;sections bookmarks&quot;&gt;&lt;/div&gt;">
-                                                <i class="material-icons je-copy-icon">content_copy</i>
-                                                <span class="copy-btn-text je-copy-btn-text">Copy</span>
-                                            </button>
-                                            <pre class="je-code-pre"><code>&lt;div class="sections bookmarks"&gt;&lt;/div&gt;
-</code></pre>
-                                        </div>
-                                        <div class="fieldDescription je-field-desc-mt">
-                                            Already have Custom Tabs installed?
-                                            <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
-                                        </div>
-                                    </div>
+                            <div class="je-setting-description" data-desc-for="watchProgressTimeFormat">
+                                <div class="fieldDescription">Select how time-based progress is shown.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="showFileSizes" is="emby-checkbox" type="checkbox"/><span>Show file sizes</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showFileSizes">
+                                <div class="fieldDescription">Display the file size of each video file on item detail pages.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="showAudioLanguages" is="emby-checkbox" type="checkbox"/><span>Show available audio languages on item detail page</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showAudioLanguages">
+                                <div class="fieldDescription">List the audio language flags available for each title on its detail page.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="removeContinueWatchingEnabled" is="emby-checkbox" type="checkbox"/><span>Enable "Remove from Continue Watching"</span></label></div>
+                            <div class="je-setting-description" data-desc-for="removeContinueWatchingEnabled">
+                                <div class="fieldDescription">Adds a "Remove from Continue Watching" option to the right-click / long-press context menu so users can clear individual items from their Continue Watching row.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Media Tags</legend>
+                        <div class="configSection">
+                            <div class="je-tag-row">
+                                <div class="checkboxContainer"><label><input id="qualityTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Quality Tags</span></label></div>
+                                <div class="inputContainer je-tag-position">
+                                    <label class="inputLabel" for="qualityTagsPosition">Position</label>
+                                    <select is="emby-select" id="qualityTagsPosition" name="qualityTagsPosition" class="emby-select">
+                                        <option value="top-left">Top Left</option><option value="top-right">Top Right</option><option value="bottom-left">Bottom Left</option><option value="bottom-right">Bottom Right</option>
+                                    </select>
                                 </div>
                             </div>
+                            <div class="je-setting-description" data-desc-for="qualityTagsEnabled">
+                                <div class="fieldDescription je-field-desc-sm">This feature is a slightly modified version of the original script by <a class="sectionTitle" href="https://github.com/BobHasNoSoul/Jellyfin-Qualitytags/" target="_blank">BobHasNoSoul</a></div>
+                            </div>
+
+                            <div class="je-tag-row">
+                                <div class="checkboxContainer"><label><input id="genreTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Genre Tags</span></label></div>
+                                <div class="inputContainer je-tag-position">
+                                    <label class="inputLabel" for="genreTagsPosition">Position</label>
+                                    <select is="emby-select" id="genreTagsPosition" name="genreTagsPosition" class="emby-select">
+                                        <option value="top-left">Top Left</option><option value="top-right">Top Right</option><option value="bottom-left">Bottom Left</option><option value="bottom-right">Bottom Right</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="genreTagsEnabled">
+                                <div class="fieldDescription">Identify genres with themed icons on poster cards.</div>
+                            </div>
+
+                            <div class="je-tag-row">
+                                <div class="checkboxContainer"><label><input id="languageTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Language Tags</span></label></div>
+                                <div class="inputContainer je-tag-position">
+                                    <label class="inputLabel" for="languageTagsPosition">Position</label>
+                                    <select is="emby-select" id="languageTagsPosition" name="languageTagsPosition" class="emby-select">
+                                        <option value="top-left">Top Left</option><option value="top-right">Top Right</option><option value="bottom-left">Bottom Left</option><option value="bottom-right">Bottom Right</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="languageTagsEnabled">
+                                <div class="fieldDescription">Display available audio languages as country flags on poster cards.</div>
+                            </div>
+
+                            <div class="je-tag-row">
+                                <div class="checkboxContainer"><label><input id="ratingTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Rating Tags</span></label></div>
+                                <div class="inputContainer je-tag-position">
+                                    <label class="inputLabel" for="ratingTagsPosition">Position</label>
+                                    <select is="emby-select" id="ratingTagsPosition" name="ratingTagsPosition" class="emby-select">
+                                        <option value="top-left">Top Left</option><option value="top-right">Top Right</option><option value="bottom-left">Bottom Left</option><option value="bottom-right">Bottom Right</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="ratingTagsEnabled">
+                                <div class="fieldDescription">Show TMDB and Rotten Tomatoes ratings on poster cards.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="peopleTagsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable People Tags</span></label></div>
+                            <div class="je-setting-description" data-desc-for="peopleTagsEnabled">
+                                <div class="fieldDescription">Display age and birthplace information for cast members on item detail pages.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="tagsCacheTtlDays">Tags Cache Duration (days)</label>
+                                <input id="tagsCacheTtlDays" is="emby-input" type="number" min="1" max="365" value="30"/>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="tagsCacheTtlDays">
+                                <div class="fieldDescription">How long to cache the above tags data (1–365 days, default: 30).</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="showRatingInPlayer" is="emby-checkbox" type="checkbox"/><span>Show Rating in Video Player</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showRatingInPlayer">
+                                <div class="fieldDescription">Display TMDB and Rotten Tomatoes ratings before "Ends at" time in video player.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="disableTagsOnSearchPage" is="emby-checkbox" type="checkbox"/><span>Disable Tags on Search Page</span></label></div>
+                            <div class="je-setting-description" data-desc-for="disableTagsOnSearchPage">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">Prevents quality/language/genre/rating tags from showing on search results. Recommended for compatibility with <b>Gelato</b> plugin.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="tagsHideOnHover" is="emby-checkbox" type="checkbox"/><span>Hide Tags on Hover</span></label></div>
+                            <div class="je-setting-description" data-desc-for="tagsHideOnHover">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, tag overlays fade out when users hover over cards. Users can override this in their personal settings.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="tagCacheServerMode" is="emby-checkbox" type="checkbox"/><span>Server-Side Tag Cache</span></label></div>
+                            <div class="je-setting-description" data-desc-for="tagCacheServerMode">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">Pre-computes tag data on the server and serves it in a single request. Tags load instantly without per-page API calls. Disable to use the legacy per-page batch mode (not recommended).</div>
+                            </div>
+
+                            <div id="tagsLocalStorageFallbackContainer" class="checkboxContainer">
+                                <label><input id="enableTagsLocalStorageFallback" is="emby-checkbox" type="checkbox"/><span>Persist Tag Fallback Cache in Browser Storage</span></label>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="enableTagsLocalStorageFallback">
+                                <div class="fieldDescription je-field-desc-sm-font-xl">Available when Server-Side Tag Cache is disabled. Stores fallback tag cache entries in browser localStorage for faster repeat loads.</div>
+                            </div>
+
+                            <div id="clientTagCacheControls" style="margin-top:10px;">
+                                <button id="clearTagsCacheBtn" class="raised button-submit emby-button" is="emby-button" type="button" style="width: 100%;">
+                                    <span>Clear All Client Caches</span>
+                                </button>
+                                <div class="fieldDescription">Forces clients to clear caches on next load. May cause initial slowness.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Icons &amp; Theme</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="useIcons" is="emby-checkbox" type="checkbox"/><span>Use Icons in UI</span></label></div>
+                            <div class="je-setting-description" data-desc-for="useIcons">
+                                <div class="fieldDescription je-field-desc-lg">Display icons throughout the UI (toasts, settings panel headers, etc.)</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="iconStyle">Icon Style</label>
+                                <select id="iconStyle" name="iconStyle" is="emby-select" class="emby-select">
+                                    <option value="emoji">Emoji</option>
+                                    <option value="lucide">Lucide Icons</option>
+                                    <option value="mui">Material UI Icons</option>
+                                </select>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="iconStyle">
+                                <div class="fieldDescription">Choose between emoji characters, Lucide icons, or Material UI icons.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Random Button</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="randomButtonEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Random Button</span></label></div>
+                            <div class="je-setting-description" data-desc-for="randomButtonEnabled">
+                                <div class="fieldDescription">Adds a "Play Random" button to the Jellyfin header that picks an item at random from the user's accessible libraries and plays it.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="randomUnwatchedOnly" is="emby-checkbox" type="checkbox"/><span>Show unwatched only</span></label></div>
+                            <div class="je-setting-description" data-desc-for="randomUnwatchedOnly">
+                                <div class="fieldDescription">When enabled, the random picker only chooses items the user has not watched yet.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="randomIncludeMovies" is="emby-checkbox" type="checkbox"/><span>Include movies</span></label></div>
+                            <div class="je-setting-description" data-desc-for="randomIncludeMovies">
+                                <div class="fieldDescription">Include movies in the random pool.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="randomIncludeShows" is="emby-checkbox" type="checkbox"/><span>Include shows</span></label></div>
+                            <div class="je-setting-description" data-desc-for="randomIncludeShows">
+                                <div class="fieldDescription">Include TV episodes in the random pool.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div id="playback" class="jellyfin-tab-content">
+                    <fieldset>
+                        <legend class="sectionTitle">Playback &amp; Tab Switch</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="autoPauseEnabled" is="emby-checkbox" type="checkbox"/><span>Auto-pause on tab switch</span></label></div>
+                            <div class="je-setting-description" data-desc-for="autoPauseEnabled">
+                                <div class="fieldDescription">Pause playback automatically when you switch to another browser tab.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="autoResumeEnabled" is="emby-checkbox" type="checkbox"/><span>Auto-resume on tab switch</span></label></div>
+                            <div class="je-setting-description" data-desc-for="autoResumeEnabled">
+                                <div class="fieldDescription">Resume playback automatically when you switch back to the player tab.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="autoPipEnabled" is="emby-checkbox" type="checkbox"/><span>Auto Picture-in-Picture on tab switch</span></label></div>
+                            <div class="je-setting-description" data-desc-for="autoPipEnabled">
+                                <div class="fieldDescription">Enter the browser's Picture-in-Picture mode when switching tabs (browser support required).</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="longPress2xEnabled" is="emby-checkbox" type="checkbox"/><span>Long press/hold for 2x speed <sup> β</sup></span></label></div>
+                            <div class="je-setting-description" data-desc-for="longPress2xEnabled">
+                                <div class="fieldDescription">Long-press anywhere on the player to temporarily play at 2× speed; release to return to normal speed. Beta — touch devices only.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="pauseScreenEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Custom Pause Screen</span></label></div>
+                            <div class="je-setting-description" data-desc-for="pauseScreenEnabled">
+                                <div class="fieldDescription je-field-desc-sm">This feature is a modified version of the original script by <a class="sectionTitle" href="https://github.com/BobHasNoSoul/Jellyfin-PauseScreen" target="_blank">BobHasNoSoul</a></div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Auto-Skip</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="autoSkipIntro" is="emby-checkbox" type="checkbox"/><span>Auto-skip Intro</span></label></div>
+                            <div class="je-setting-description" data-desc-for="autoSkipIntro">
+                                <div class="fieldDescription">Automatically skip detected intros. Requires the Intro Skipper plugin.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="autoSkipOutro" is="emby-checkbox" type="checkbox"/><span>Auto-skip Outro</span></label></div>
+                            <div class="je-setting-description" data-desc-for="autoSkipOutro">
+                                <div class="fieldDescription">Automatically skip detected outros (end credits). Requires the Intro Skipper plugin.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Subtitles &amp; Language</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="disableCustomSubtitleStyles" is="emby-checkbox" type="checkbox"/><span>Disable Custom Subtitle Styles by default</span></label></div>
+                            <div class="je-setting-description" data-desc-for="disableCustomSubtitleStyles">
+                                <div class="fieldDescription">Globally disables Jellyfin's custom subtitle style overrides so the source subtitle styling is shown unmodified.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="DefaultSubtitleStyle">Default Subtitle Style</label>
+                                <select is="emby-select" id="DefaultSubtitleStyle" name="DefaultSubtitleStyle" class="emby-select">
+                                    <option value="0">Clean White</option><option value="1">Classic Black Box</option><option value="2">Netflix Style</option>
+                                    <option value="3">Cinema Yellow</option><option value="4">Soft Gray</option><option value="5">High Contrast</option>
+                                </select>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="DefaultSubtitleStyle">
+                                <div class="fieldDescription">Default subtitle style preset applied to new users; users can override in their personal settings.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="DefaultSubtitleSize">Default Subtitle Size</label>
+                                <select is="emby-select" id="DefaultSubtitleSize" name="DefaultSubtitleSize" class="emby-select">
+                                    <option value="0">Tiny</option><option value="1">Small</option><option value="2">Normal</option>
+                                    <option value="3">Large</option><option value="4">Extra Large</option><option value="5">Gigantic</option>
+                                </select>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="DefaultSubtitleSize">
+                                <div class="fieldDescription">Default subtitle size applied to new users; users can override in their personal settings.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="DefaultSubtitleFont">Default Subtitle Font</label>
+                                <select is="emby-select" id="DefaultSubtitleFont" name="DefaultSubtitleFont" class="emby-select">
+                                    <option value="0">Default</option><option value="1">Noto Sans</option><option value="2">Sans Serif</option>
+                                    <option value="3">Typewriter</option><option value="4">Roboto</option>
+                                </select>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="DefaultSubtitleFont">
+                                <div class="fieldDescription">Default subtitle font applied to new users; users can override in their personal settings.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="DefaultLanguage">Default UI Language</label>
+                                <select is="emby-select" id="DefaultLanguage" name="DefaultLanguage" class="emby-select">
+                                    <option value="">System Default</option>
+                                </select>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="DefaultLanguage">
+                                <div class="fieldDescription">Sets the default language for all users. Users can still override this in their own settings.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Shortcuts Panel &amp; Toast Timing</legend>
+                        <div class="configSection">
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="HelpPanelAutocloseDelay">Shortcuts Panel Autoclose Delay (ms)</label>
+                                <input id="HelpPanelAutocloseDelay" is="emby-input" name="HelpPanelAutocloseDelay" type="number"/>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="HelpPanelAutocloseDelay">
+                                <div class="fieldDescription">How long the Jellyfin Enhanced shortcuts/settings panel (opened with the <kbd>?</kbd> key) stays open without interaction before auto-closing. Default: 15000 ms (15 seconds).</div>
+                            </div>
+                            <div class="je-timing-test-row">
+                                <button id="jeTestShortcutsPanel" type="button" class="emby-button raised raised-mini je-timing-test-btn" aria-label="Preview shortcuts panel autoclose">
+                                    <i class="material-icons" aria-hidden="true">visibility</i><span>Preview autoclose</span>
+                                </button>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="ToastDuration">Toast Notification Duration (ms)</label>
+                                <input id="ToastDuration" is="emby-input" name="ToastDuration" type="number"/>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="ToastDuration">
+                                <div class="fieldDescription">How long Jellyfin Enhanced's pop-up toast messages (e.g. &ldquo;Shuffle enabled&rdquo;, &ldquo;Bookmark saved&rdquo;) stay on-screen before fading out. Default: 3000 ms (3 seconds).</div>
+                            </div>
+                            <div class="je-timing-test-row">
+                                <button id="jeTestToast" type="button" class="emby-button raised raised-mini je-timing-test-btn" aria-label="Preview toast notification">
+                                    <i class="material-icons" aria-hidden="true">notifications_active</i><span>Preview toast</span>
+                                </button>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div id="pages" class="jellyfin-tab-content">
+                    <div class="je-info-banner je-fieldset-wide je-tab-intro">
+                        <i class="material-icons je-info-icon">integration_instructions</i>
+                        <div>
+                            These features add or replace pages in the Jellyfin web UI. Support integration with <a target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-pages">Plugin Pages</a> (sidebar) or <a target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs">Custom Tabs</a> (home page).
+                        </div>
+                    </div>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Bookmarks</legend>
+                        <div class="configSection">
                             <div class="je-info-banner-inline">
                                 <div class="je-info-banner-row">
                                     <i class="material-icons je-info-icon">info</i>
@@ -361,1389 +492,1325 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Timeout Settings</h3></legend>
-                        <div class="configSection">
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="HelpPanelAutocloseDelay">Help Panel Autoclose Delay (in milliseconds)</label>
-                                <input id="HelpPanelAutocloseDelay" is="emby-input" name="HelpPanelAutocloseDelay" type="number"/>
-                                <div class="fieldDescription">How long the help panel stays open before auto-closing.</div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="ToastDuration">Toast Duration (in milliseconds)</label>
-                                <input id="ToastDuration" is="emby-input" name="ToastDuration" type="number"/>
-                                <div class="fieldDescription">How long toast notifications are displayed.</div>
-                            </div>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Hidden Content</h3></legend>
-                        <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="hiddenContentEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Hidden Content</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Enable or disable the Hidden Content feature server-wide. When disabled, hide buttons, filtering, sidebar navigation, and settings panel options are all removed. User data is preserved and restored when re-enabled.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="hiddenContentUsePluginPages" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Plugin Pages for Hidden Content</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Replaces the default Hidden Content page with a <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-pages">Plugin Pages</a> implementation.<br><strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="hiddenContentUseCustomTabs" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Custom Tabs for Hidden Content (instead of sidebar)</span>
-                                </label>
-                            </div>
-                            <div class="je-info-banner-inline">
-                                <div class="je-info-banner-row">
-                                    <i class="material-icons je-info-icon">info</i>
-                                    <div>
-                                        <h4 class="je-custom-tabs-h4">Embed Hidden Content in Custom Tabs:</h4>
-                                        <p class="fieldDescription je-custom-tabs-p">Display the Hidden Content page in a Custom Tabs tab instead of the sidebar link.</p>
-                                        <p class="fieldDescription je-custom-tabs-p-mt">You need the <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs">Custom Tabs</a> plugin.</p>
-                                        <ol class="fieldDescription je-custom-tabs-ol">
-                                            <li class="je-custom-tabs-li">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
-                                            <li class="je-custom-tabs-li">Navigate to Dashboard > Plugins > Custom Tabs and add a new tab.</li>
-                                            <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Hidden Content").</li>
-                                            <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
-                                        </ol>
-                                        <div class="je-copy-code-wrapper">
-                                            <button type="button" class="je-copy-html-btn raised raised-mini emby-button" data-copy-text="&lt;div class=&quot;jellyfinenhanced hidden-content&quot;&gt;&lt;/div&gt;">
-                                                <i class="material-icons je-copy-icon">content_copy</i>
-                                                <span class="copy-btn-text je-copy-btn-text">Copy</span>
-                                            </button>
-                                            <pre class="je-code-pre"><code>&lt;div class="jellyfinenhanced hidden-content"&gt;&lt;/div&gt;
-</code></pre>
-                                        </div>
-                                        <div class="fieldDescription je-field-desc-mt">
-                                            Already have Custom Tabs installed?
-                                            <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-
-                <div id="elsewhere" class="jellyfin-tab-content">
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Configuration</h3></legend>
-                        <div class="checkboxContainer je-checkbox-mb-2">
-                            <label>
-                                <input id="elsewhereEnabled" is="emby-checkbox" type="checkbox"/>
-                                <span>Enable Elsewhere<div class="je-elsewhere-subtitle">Show Streaming Provider Lookup on Item Details Page</div></span>
-                            </label>
-                        </div>
-                        <div class="configSection">
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="TMDB_API_KEY">TMDB API Key</label>
-                                <div class="je-api-row">
-                                    <input id="TMDB_API_KEY" is="emby-input" name="TMDB_API_KEY" type="text" class="je-api-input"/>
-                                    <span id="tmdbStatusIndicator" class="material-icons je-status-indicator"></span>
-                                    <button is="emby-button" type="button" class="testTmdbBtn raised button-submit">
-                                        <span>Test</span>
-                                    </button>
-                                </div>
-                                <div class="fieldDescription">Your API key from The Movie DB (TMDB). <a class="sectionTitle" target="_blank" href="https://www.themoviedb.org/settings/api">How to?</a></div>
-                                <div class="fieldDescription"><br>Shared with Seerr Settings</div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="DEFAULT_REGION">Default Region</label>
-                                <input id="DEFAULT_REGION" is="emby-input" name="DEFAULT_REGION" type="text" placeholder="e.g., US"/>
-                                <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" target="_blank" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt">Full List</a></div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="DEFAULT_PROVIDERS">Default Providers</label>
-                                <textarea class="emby-textarea emby-input je-textarea-tall" id="DEFAULT_PROVIDERS" name="DEFAULT_PROVIDERS" placeholder="e.g., Netflix,Hulu"></textarea>
-                                <div class="fieldDescription">A list of default streaming providers to show. Leave blank to show all. <a class="sectionTitle" target="_blank" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt">Full List</a></div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="IGNORE_PROVIDERS">Ignore Providers</label>
-                                <textarea class="emby-textarea emby-input je-textarea-tall" id="IGNORE_PROVIDERS" name="IGNORE_PROVIDERS" placeholder="e.g., .*with Ads, Hulu"></textarea>
-                                <div class="fieldDescription">A list of providers to ignore from the default region (supports regex).<a class="sectionTitle" target="_blank" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt">Full List</a></div>
-                            </div>
-                            <h3>Elsewhere Custom Branding</h3>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="ElsewhereCustomBrandingText">Custom Branding Message</label>
-                                <input id="ElsewhereCustomBrandingText" is="emby-input" name="ElsewhereCustomBrandingText" type="text" placeholder="e.g., Only available on My Server"/>
-                                <div class="fieldDescription">Custom message to display when content is not available on any streaming providers. Leave blank to disable custom branding.</div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="ElsewhereCustomBrandingImageUrl">Custom Branding Icon URL</label>
-                                <input id="ElsewhereCustomBrandingImageUrl" is="emby-input" name="ElsewhereCustomBrandingImageUrl" type="text" placeholder="e.g., /web/assets/img/icon.png"/>
-                                <div class="fieldDescription">Optional URL for an icon to display next to the custom message. Leave blank for no icon.</div>
-                            </div>
-                            <h3 class="je-h3-mt">Extras</h3>
-                            <div class="checkboxContainer">
-                                <label class="je-elsewhere-label"><input id="showReviews" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show Reviews from TMDB in Item Details Page</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-sm-font-lg">Requires TMDB API Key to be set</div>
-                            <div class="checkboxContainer">
-                                <label class="je-elsewhere-label"><input id="reviewsExpandedByDefault" is="emby-checkbox" type="checkbox"/>
-                                    <span>Expand reviews by default</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, the reviews section opens expanded by default for all users (unless they override in their session).</div>
-                            <h3 class="je-h3-mt-lg">User Reviews</h3>
-                            <h5>These settings do not require TMDB API key to be populated</h5>
-                            <div class="checkboxContainer">
-                                <label class="je-elsewhere-label"><input id="showUserReviews" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable User Reviews in Item Details Page</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-sm-font-lg">Allows users to write reviews and rate items in the library.<br/><strong>Completely independent of Elsewhere being enabled and TMDB Reviews being enabled</strong></div>
-                            <div class="checkboxContainer">
-                                <label class="je-elsewhere-label"><input id="hideReviewsFromHiddenUsers" is="emby-checkbox" type="checkbox"/>
-                                    <span>Hide reviews written by hidden users</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, reviews written by Jellyfin users marked as "Hide this user from login screens" are hidden from non-admin viewers. Admins always see all reviews.</div>
-                            <div class="checkboxContainer">
-                                <label class="je-elsewhere-label"><input id="hideReviewsFromDisabledUsers" is="emby-checkbox" type="checkbox"/>
-                                    <span>Hide reviews written by disabled users</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, reviews written by Jellyfin users marked as "Disable this user" are hidden from non-admin viewers. Admins always see all reviews.</div>
-                        </div>
-                    </fieldset>
-                </div>
-                <div id="jellyseerr" class="jellyfin-tab-content">
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Setup</h3></legend>
-                        <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="jellyseerrEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Seerr integration</span>
-                                </label>
+                            <div class="checkboxContainer"><label><input id="bookmarksEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Bookmarks Feature</span></label></div>
+                            <div class="je-setting-description" data-desc-for="bookmarksEnabled">
+                                <div class="fieldDescription je-field-desc-lg">Save custom bookmarks/timestamps while watching videos to quickly jump back to your favorite scenes or moments.</div>
                             </div>
 
-                            <div class="inputContainer">
-                                <label class="sectionTitle je-seerr-label" for="jellyseerrUrls">Seerr URL(s)</label>
-                                <textarea class="emby-textarea emby-input je-textarea-medium" id="jellyseerrUrls" name="jellyseerrUrls" placeholder="http://192.168.1.10:5055&#10;https://jellyseerr.example.com"></textarea>
-                                <div class="fieldDescription">Enter your Seerr instance URLs, one per line. The script will use the first one that connects successfully.</div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="JellyseerrApiKey">Seerr API Key</label>
-                                <div class="je-api-row">
-                                    <input id="JellyseerrApiKey" is="emby-input" name="JellyseerrApiKey" type="text" class="je-api-input"/>
-                                    <span id="jellyseerrStatusIndicator" class="material-icons je-status-indicator"></span>
-                                    <button is="emby-button" type="button" id="testJellyseerrBtn" class="raised button-submit">
-                                        <span>Test</span>
-                                    </button>
+                            <div class="checkboxContainer"><label><input id="bookmarksUsePluginPages" is="emby-checkbox" type="checkbox"/><span>Use Plugin Pages for Bookmarks Library</span></label></div>
+                            <div class="je-setting-description" data-desc-for="bookmarksUsePluginPages">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    Adds a "Bookmarks" link to the sidebar via <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-pages" target="_blank">Plugin Pages</a>.<br/>
+                                    <strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.
+                                    <span class="je-installed-badge" data-plugin="pluginpages"><i class="material-icons" aria-hidden="true">check_circle</i>Plugin Pages detected</span>
                                 </div>
-                                <div class="fieldDescription">API key from Seerr. (Settings > General Settings >  API Key)</div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="jellyseerr_TMDB_API_KEY">TMDB API Key</label>
-                                <div class="je-api-row">
-                                    <input id="jellyseerr_TMDB_API_KEY" is="emby-input" name="TMDB_API_KEY" type="text" class="je-api-input"/>
-                                    <span id="jellyseerrTmdbStatusIndicator" class="material-icons je-status-indicator"></span>
-                                    <button is="emby-button" type="button" class="testTmdbBtn raised button-submit">
-                                        <span>Test</span>
-                                    </button>
-                                </div>
-                                <div class="fieldDescription">Your API key from The Movie DB (TMDB). <a class="sectionTitle" target="_blank" href="https://www.themoviedb.org/settings/api">How to?</a><br>TMDB API key for automatic movie collection requests and Seerr Collection Results. Shared with Elsewhere Settings</div>
                             </div>
 
-                            <details class="je-seerr-details">
-                                <summary class="je-details-section-summary">Advanced URL Mappings (Optional)</summary>
-                                <div class="je-details-body">
-                                    <div class="inputContainer">
-                                        <label class="sectionTitle je-seerr-label" for="jellyseerrUrlMappings">Seerr URL Mappings</label>
-                                        <textarea class="emby-textarea emby-input je-textarea-large" id="jellyseerrUrlMappings" name="jellyseerrUrlMappings" placeholder="https://jellyfin.mydomain.com|https://jellyseerr.mydomain.com&#10;http://192.168.1.10:8096|http://192.168.1.10:5055&#10;https://example.com/jellyfin|https://example.com/jellyseerr"></textarea>
-                                        <div class="fieldDescription">Map your Jellyfin URLs to specific Seerr URLs for displaying links to users. Users will get the appropriate Seerr link when using "Link result titles to Seerr instead of TMDB", based on what link they use to access Jellyfin. <br>Format: <code>JellyfinURL|SeerrURL</code>, one mapping per line.<br>If no mapping matches or this is empty, the first URL from above will be used.</div>
-                                        <div class="je-validation-result">
-                                            <button is="emby-button" type="button" id="validateSeerrMappingsBtn" class="raised button-submit emby-button">
-                                                <span>Validate Mappings</span>
-                                            </button>
-                                            <div id="seerrMappingsValidationResult" style="display: none;"></div>
-                                        </div>
-                                    </div>
-                                    <div
-                                        class="je-info-banner-inline">
-                                        <i class="material-icons je-info-icon-sm">info</i>
+                            <div class="checkboxContainer"><label><input id="bookmarksUseCustomTabs" is="emby-checkbox" type="checkbox"/><span>Use Custom Tabs for Bookmarks</span></label></div>
+
+                            <div class="checkboxContainer je-customtabs-automanage" data-gated-by="bookmarksUseCustomTabs,bookmarksEnabled">
+                                <label><input id="bookmarksAutoCreateCustomTab" is="emby-checkbox" type="checkbox"/><span>Add the Custom Tabs entry for me</span></label>
+                            </div>
+                            <div class="je-setting-description je-customtabs-automanage" data-desc-for="bookmarksAutoCreateCustomTab" data-gated-by="bookmarksUseCustomTabs,bookmarksEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Jellyfin Enhanced will create the matching Custom Tabs entry on save. Turning off "Use Custom Tabs for Bookmarks" removes the entry; turning it back on re-creates it. Leave unchecked to manage the Custom Tabs entry yourself.
+                                </div>
+                            </div>
+
+                            <div class="je-setting-description" data-desc-for="bookmarksUseCustomTabs">
+                                <div class="je-info-banner-inline">
+                                    <div class="je-info-banner-row">
+                                        <i class="material-icons je-info-icon">info</i>
                                         <div>
-                                            <strong>URL Mapping Examples:</strong><br>
-                                            • Remote access: <code>https://jellyfin.mydomain.com|https://jellyseerr.mydomain.com</code><br>
-                                            • Local access: <code>http://192.168.1.10:8096|http://192.168.1.10:5055</code><br>
-                                            • With base URL: <code>https://example.com/jellyfin|https://example.com/jellyseerr</code><br><br>
+                                            <h4 class="je-custom-tabs-h4">
+                                                Embed Bookmarks in Custom Tabs:
+                                                <span class="je-installed-badge" data-plugin="customtabs"><i class="material-icons" aria-hidden="true">check_circle</i>Custom Tabs detected</span>
+                                            </h4>
+                                            <p class="fieldDescription je-custom-tabs-p">Display the Bookmarks library in a Custom Tabs tab instead of the sidebar link.</p>
+                                            <p class="fieldDescription je-custom-tabs-p-mt je-needs-customtabs">You need the <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs" target="_blank">Custom Tabs</a> plugin.</p>
+                                            <ol class="fieldDescription je-custom-tabs-ol">
+                                                <li class="je-custom-tabs-li je-needs-customtabs">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
+                                                <li class="je-custom-tabs-li">Navigate to Dashboard &gt; Plugins &gt; Custom Tabs and add a new tab.</li>
+                                                <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Bookmarks").</li>
+                                                <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
+                                            </ol>
+                                            <div class="je-copy-code-wrapper">
+                                                <button class="je-copy-html-btn raised raised-mini emby-button" data-copy-text='&lt;div class="sections bookmarks"&gt;&lt;/div&gt;' type="button">
+                                                    <i class="material-icons je-copy-icon">content_copy</i>
+                                                    <span class="copy-btn-text je-copy-btn-text">Copy</span>
+                                                </button>
+                                                <pre class="je-code-pre"><code>&lt;div class="sections bookmarks"&gt;&lt;/div&gt;</code></pre>
+                                            </div>
+                                            <div class="fieldDescription je-field-desc-mt">
+                                                Already have Custom Tabs installed?
+                                                <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
+                                            </div>
                                         </div>
                                     </div>
-                                    <div
-                                        class="je-mobile-banner">
-                                        <i class="material-icons je-mobile-icon">phone_android</i>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Hidden Content</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="hiddenContentEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Hidden Content</span></label></div>
+                            <div class="je-setting-description" data-desc-for="hiddenContentEnabled">
+                                <div class="fieldDescription je-field-desc-xl">Enable or disable the Hidden Content feature server-wide. When disabled, hide buttons, filtering, sidebar navigation, and settings panel options are all removed. User data is preserved and restored when re-enabled.</div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="hiddenContentUsePluginPages" is="emby-checkbox" type="checkbox"/><span>Use Plugin Pages for Hidden Content</span></label></div>
+                            <div class="je-setting-description" data-desc-for="hiddenContentUsePluginPages">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    Replaces the default Hidden Content page with a <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-pages" target="_blank">Plugin Pages</a> implementation.<br/>
+                                    <strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.
+                                    <span class="je-installed-badge" data-plugin="pluginpages"><i class="material-icons" aria-hidden="true">check_circle</i>Plugin Pages detected</span>
+                                </div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="hiddenContentUseCustomTabs" is="emby-checkbox" type="checkbox"/><span>Use Custom Tabs for Hidden Content</span></label></div>
+
+                            <div class="checkboxContainer je-customtabs-automanage" data-gated-by="hiddenContentUseCustomTabs,hiddenContentEnabled">
+                                <label><input id="hiddenContentAutoCreateCustomTab" is="emby-checkbox" type="checkbox"/><span>Add the Custom Tabs entry for me</span></label>
+                            </div>
+                            <div class="je-setting-description je-customtabs-automanage" data-desc-for="hiddenContentAutoCreateCustomTab" data-gated-by="hiddenContentUseCustomTabs,hiddenContentEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Jellyfin Enhanced will create the matching Custom Tabs entry on save. Turning off "Use Custom Tabs for Hidden Content" removes the entry; turning it back on re-creates it. Leave unchecked to manage the Custom Tabs entry yourself.
+                                </div>
+                            </div>
+
+                            <div class="je-setting-description" data-desc-for="hiddenContentUseCustomTabs">
+                                <div class="je-info-banner-inline">
+                                    <div class="je-info-banner-row">
+                                        <i class="material-icons je-info-icon">info</i>
                                         <div>
-                                             Make sure proper mappings are added to appropriate URLs in order for mobile clients to open Seerr links correctly.
-                                        </div>
-                                    </div>
-                                </div>
-                            </details>
-
-                            <div
-                                class="je-info-banner-inline-center">
-                                <i class="material-icons je-info-icon-sm">info</i>
-                                <div>
-                                    "<b>Enable Jellyfin Sign-In</b>" must be enabled in Seerr User Settings (/settings/users)<br><br>
-                                    All users must be imported to Seerr as Jellyfin users for them to be able to request content.
-                                </div>
-                            </div>
-                            <div
-                                class="je-purple-banner">
-                                <i class="material-icons je-purple-icon">favorite</i>
-                                <div>
-                                    <b>Jellyfin Enhanced is not affiliated with Seerr.</b><br><br>
-                                    Seerr is an independent project. This plugin only uses Seerr's public API to integrate request and discovery features into Jellyfin.<br><br>
-                                    A huge thanks to the Seerr team for building and maintaining an excellent open-source project.<br><br>
-                                    <b>If you encounter issues related with this plugin, please report them to the <a href="https://github.com/n00bcodr/Jellyfin-Enhanced/issues" target="_blank" class="sectionTitle">Jellyfin Enhanced issue tracker</a>, not the Seerr team!</b>
-                                </div>
-                            </div>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Search</h3></legend>
-                        <div class="configSection">
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary">Search Integration</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowSearchResults" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show Seerr Results in Search</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">Enhance Jellyfin search by showing results from Seerr.<br>This allows users to discover and request missing movies and shows directly from Jellyfin.</div>
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="showCollectionsInSearch" is="emby-checkbox" type="checkbox" data-plugin-config/>
-                                            <span>Show Collections in Seerr Search Results</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">Display TMDB collections (e.g., Harry Potter, Marvel Cinematic Universe) in Seerr search results with an option to request the entire collection at once.<br><br><b>Requires TMDB API Key to be configured.</b></div>
-                                </div>
-                            </details>
-
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary">Request Options</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrEnable4kRequests" is="emby-checkbox" type="checkbox"/>
-                                            <span>Enable 4K Requests</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">When enabled, movie request buttons include a dropdown to request a 4K version.</div>
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrEnable4kTvRequests" is="emby-checkbox" type="checkbox"/>
-                                            <span>Enable 4K TV Requests</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">When enabled, TV request buttons include a dropdown that opens the season request modal in 4K mode.</div>
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowAdvanced" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show advanced request options</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">Enable this if you want users to be able to choose between Servers, Quality and Paths while requesting. <br> Note: This will disregard any Override Rules set in Seerr.</div>
-                                </div>
-                            </details>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Other Features</h3></legend>
-                        <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="jellyseerrUseMoreInfoModal" is="emby-checkbox" type="checkbox"/>
-                                    <span>Open result titles and posters in "More Info" modal</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, clicking a Seerr result title or poster opens an in-app More Info modal.<br>When disabled, clicking will open the item in Seerr.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="jellyseerrShowReportButton" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show "Report Issue" button on item detail pages</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, a small report icon will be added to item action icons allowing users to report playback/content issues to Seerr.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="jellyseerrShowIssueIndicator" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show open issue indicator on the report button</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, the report issue button turns orange and shows a count badge if the item has open issues in Seerr.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="jellyseerrExcludeBlocklistedItems" is="emby-checkbox" type="checkbox"/>
-                                    <span>Exclude blocklisted movies/series from suggestions</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, items marked as blocklisted in Seerr will not appear in similar/recommended suggestions.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="showElsewhereOnJellyseerr" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show Streaming Providers on Seerr Posters</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Displays icons of available streaming services (from your default region) on Seerr Posters.<br><br><b>Requires TMDB API Key to be configured in Elsewhere Settings</b></div>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Discovery & Recommendations</h3></legend>
-                        <div class="configSection">
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary">Item Detail Page</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowSimilar" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show similar items on item details page</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">Displays similar movies/shows from Seerr on item details pages. Limited to 20 items.</div>
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowRecommended" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show recommended items on item details page</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">Displays recommended movies/shows from Seerr on item details pages. Limited to 20 items.</div>
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowRequestMoreOnSeries" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show "Request More" button next to Seasons heading on Series pages</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">Adds a "Request More" button beside the Seasons section heading on Series detail pages when the show has unrequested seasons in Seerr. Lets users request additional seasons without going through the search bar.</div>
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrExcludeLibraryItems" is="emby-checkbox" type="checkbox"/>
-                                            <span>Exclude items already in library</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">Hide similar/recommended items that already exist in your Jellyfin library from the results.<br>If disabled, the items that are available link to the media item in the library.</div>
-                                </div>
-                            </details>
-
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary">"More" Discovery</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowNetworkDiscovery" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show "More from [Network]" on studio/network pages</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-md">When viewing a network page (e.g., Netflix, HBO), displays additional content from that network available in Seerr.</div>
-
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowGenreDiscovery" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show "More [Genre]" on genre pages</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-md">When viewing a genre page (e.g., Action, Comedy), displays additional content in that genre from Seerr.</div>
-
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowTagDiscovery" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show "More [Tag]" on tag pages</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-md">When viewing a tag page (e.g., cooking, superhero), displays additional content with that keyword from Seerr.</div>
-
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowPersonDiscovery" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show "More from [Actor]" on person pages</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-md">When viewing an actor/person page, displays their filmography from Seerr including content not in your library.</div>
-
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="jellyseerrShowCollectionDiscovery" is="emby-checkbox" type="checkbox"/>
-                                            <span>Show missing collection movies on BoxSet pages</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">When viewing a collection/BoxSet page, shows movies from the collection that are not yet in your library with request buttons.</div>
-                                </div>
-                            </details>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Testing / Debug</h3></legend>
-                        <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="jellyseerrDisableCache" is="emby-checkbox" type="checkbox"/>
-                                    <span>Disable server-side response cache</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, all Seerr proxy requests bypass the server-side cache and are fetched fresh from Seerr every time. This is useful for testing but will increase load on your Seerr instance. <b>Not recommended for normal use.</b></div>
-                            <div class="inputContainer je-input-mb">
-                                <label class="inputLabel inputLabelUnfocused" for="jellyseerrResponseCacheTtlMinutes">Response Cache TTL (minutes)</label>
-                                <input id="jellyseerrResponseCacheTtlMinutes" is="emby-input" type="number" min="1" max="1440" value="10"/>
-                                <div class="fieldDescription">How long Seerr API responses (search, discovery, recommendations) are cached. Default: 10 minutes.</div>
-                            </div>
-                            <div class="inputContainer je-input-mb">
-                                <label class="inputLabel inputLabelUnfocused" for="jellyseerrUserIdCacheTtlMinutes">User ID Cache TTL (minutes)</label>
-                                <input id="jellyseerrUserIdCacheTtlMinutes" is="emby-input" type="number" min="1" max="1440" value="30"/>
-                                <div class="fieldDescription">How long the Jellyfin → Seerr user ID mapping is cached. Default: 30 minutes.</div>
-                            </div>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Requests Page</h3></legend>
-                        <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="downloadsPageEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Requests Page</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Adds a "Requests" link to the navigation showing active downloads and requests.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="showDownloadsInRequests" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show Downloads in Requests Page</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Shows active downloads from Sonarr/Radarr on the Requests page. (Requires *arr links and API keys to be configured)</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="downloadsFilterByUserRequests" is="emby-checkbox" type="checkbox"/>
-                                    <span>Filter Downloads by User Requests</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, non-admin users only see downloads for content they requested. When disabled, all authenticated users can see every item in the download queue, including content requested by other users.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="downloadsPageShowIssues" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show Seerr Issues Section</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Shows open/resolved Seerr issues beneath Requests.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="downloadsUsePluginPages" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Plugin Pages for Requests Page</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Replaces the default Requests page with a <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-pages">Plugin Pages</a> implementation.<br><strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="downloadsUseCustomTabs" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Custom Tabs for Requests (instead of sidebar)</span>
-                                </label>
-                            </div>
-                            <div class="je-info-banner-inline">
-                                <div class="je-info-banner-row">
-                                    <i class="material-icons je-info-icon">info</i>
-                                    <div>
-                                        <h4 class="je-custom-tabs-h4">Embed Requests in Custom Tabs:</h4>
-                                        <p class="fieldDescription je-custom-tabs-p">Display the Requests page in a Custom Tabs tab instead of the sidebar link.</p>
-                                        <p class="fieldDescription je-custom-tabs-p-mt">You need the <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs">Custom Tabs</a> plugin.</p>
-                                        <ol class="fieldDescription je-custom-tabs-ol">
-                                            <li class="je-custom-tabs-li">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
-                                            <li class="je-custom-tabs-li">Navigate to Dashboard > Plugins > Custom Tabs and add a new tab.</li>
-                                            <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Requests")</li>
-                                            <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
-                                        </ol>
-                                        <div class="je-copy-code-wrapper">
-                                            <button type="button" class="je-copy-html-btn raised raised-mini emby-button" data-copy-text="&lt;div class=&quot;jellyfinenhanced requests&quot;&gt;&lt;/div&gt;">
-                                                <i class="material-icons je-copy-icon">content_copy</i>
-                                                <span class="copy-btn-text je-copy-btn-text">Copy</span>
-                                            </button>
-                                            <pre class="je-code-pre"><code>&lt;div class="jellyfinenhanced requests"&gt;&lt;/div&gt;
-</code></pre>
-                                        </div>
-                                        <div class="fieldDescription je-field-desc-mt">
-                                            Already have Custom Tabs installed?
-                                            <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
+                                            <h4 class="je-custom-tabs-h4">
+                                                Embed Hidden Content in Custom Tabs:
+                                                <span class="je-installed-badge" data-plugin="customtabs"><i class="material-icons" aria-hidden="true">check_circle</i>Custom Tabs detected</span>
+                                            </h4>
+                                            <p class="fieldDescription je-custom-tabs-p">Display the Hidden Content page in a Custom Tabs tab instead of the sidebar link.</p>
+                                            <p class="fieldDescription je-custom-tabs-p-mt je-needs-customtabs">You need the <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs" target="_blank">Custom Tabs</a> plugin.</p>
+                                            <ol class="fieldDescription je-custom-tabs-ol">
+                                                <li class="je-custom-tabs-li je-needs-customtabs">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
+                                                <li class="je-custom-tabs-li">Navigate to Dashboard &gt; Plugins &gt; Custom Tabs and add a new tab.</li>
+                                                <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Hidden Content").</li>
+                                                <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
+                                            </ol>
+                                            <div class="je-copy-code-wrapper">
+                                                <button class="je-copy-html-btn raised raised-mini emby-button" data-copy-text='&lt;div class="jellyfinenhanced hidden-content"&gt;&lt;/div&gt;' type="button">
+                                                    <i class="material-icons je-copy-icon">content_copy</i>
+                                                    <span class="copy-btn-text je-copy-btn-text">Copy</span>
+                                                </button>
+                                                <pre class="je-code-pre"><code>&lt;div class="jellyfinenhanced hidden-content"&gt;&lt;/div&gt;</code></pre>
+                                            </div>
+                                            <div class="fieldDescription je-field-desc-mt">
+                                                Already have Custom Tabs installed?
+                                                <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                            <div class="checkboxContainer je-checkbox-mb-1">
-                                <label>
-                                    <input id="downloadsPagePollingEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Auto-Refresh for Downloads</span>
-                                </label>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="downloadsPollIntervalSeconds">Poll Interval (seconds)</label>
-                                <input id="downloadsPollIntervalSeconds" is="emby-input" type="number" min="30" max="300"/>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">How often to refresh download status automatically. Minimum is 30 seconds and applies only when auto-refresh is enabled.</div>
                         </div>
-                        <div class="je-info-banner-inline-center">
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Requests Page</legend>
+                        <div class="configSection">
+                            <div class="je-info-banner-inline-center" style="margin-bottom: 15px;">
                                 <div class="je-info-banner-row">
                                     <i class="material-icons je-info-icon">info</i>
                                     <div>
                                         <strong>Requests Page</strong> shows a Requests Button in sidebar with a dedicated view of active downloads from Sonarr/Radarr and requests from Seerr.
-                                        <br><br>
-                                        <strong>Requirements:</strong> Configure Sonarr/Radarr and Seerr URLs and API keys.
+                                        <div id="requestsPageRequirementsLine" style="display: none; margin-top: 10px;">
+                                            <strong>Requirements:</strong> <span id="requestsPageRequirementsList">Configure Sonarr/Radarr and Seerr URLs and API keys.</span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Automatic Requests</h3></legend>
-                        <div class="configSection">
-                            <details class="je-details-section">
-                                <summary class="je-details-section-summary">Advanced Season Requests</summary>
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="autoSeasonRequestEnabled" is="emby-checkbox" type="checkbox"/>
-                                            <span>Enable Automatic Advance Season Requests</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">
-                                        Automatically request the next season in Seerr when a user about to finish the current season.
-                                        <br><br>
-                                    </div>
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="autoSeasonRequestRequireAllWatched" is="emby-checkbox" type="checkbox"/>
-                                            <span>Require All Prior Episodes Watched</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-xl">
-                                        Require all episodes before the threshold to be watched. For example, if threshold is 2 and there are 10 episodes, when watching episode 8, all episodes 1-7 must be watched or marked as watched. This prevents accidentally triggering requests by jumping to later episodes. <br> This might cause requests to not be triggered if users skip episodes.
-                                    </div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="autoSeasonRequestThresholdValue">Episodes Remaining Threshold</label>
-                                        <input id="autoSeasonRequestThresholdValue" is="emby-input" name="autoSeasonRequestThresholdValue" type="number" min="1" max="20" value="2"/>
-                                        <div class="fieldDescription">Request the next season when the number of unwatched episodes is at or below this number. Default: 2 episodes.</div>
-                                    </div>
-                                    <div
-                                        class="je-info-banner-inline">
-                                        <i class="material-icons je-info-icon-sm">info</i>
+
+                            <div class="checkboxContainer"><label><input id="downloadsPageEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Requests Page</span></label></div>
+                            <div class="je-setting-description" data-desc-for="downloadsPageEnabled">
+                                <div class="fieldDescription je-field-desc-xl">Adds a "Requests" link to the navigation showing active downloads and requests.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="showDownloadsInRequests" is="emby-checkbox" type="checkbox"/><span>Show Downloads in Requests Page</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showDownloadsInRequests">
+                                <div class="fieldDescription je-field-desc-xl">Shows active downloads from Sonarr/Radarr on the Requests page. (Requires *arr links and API keys to be configured)</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="downloadsFilterByUserRequests" is="emby-checkbox" type="checkbox"/><span>Filter Downloads by User Requests</span></label></div>
+                            <div class="je-setting-description" data-desc-for="downloadsFilterByUserRequests">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, non-admin users only see downloads for content they requested. When disabled, all authenticated users can see every item in the download queue, including content requested by other users.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="downloadsPageShowIssues" is="emby-checkbox" type="checkbox"/><span>Show Seerr Issues Section</span></label></div>
+                            <div class="je-setting-description" data-desc-for="downloadsPageShowIssues">
+                                <div class="fieldDescription je-field-desc-xl">Shows open/resolved Seerr issues beneath Requests.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="downloadsUsePluginPages" is="emby-checkbox" type="checkbox"/><span>Use Plugin Pages for Requests</span></label></div>
+                            <div class="je-setting-description" data-desc-for="downloadsUsePluginPages">
+                                <div class="fieldDescription je-field-desc-xl">Replaces the default Requests page with a <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-pages" target="_blank">Plugin Pages</a> implementation.<br/><strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.<span class="je-installed-badge" data-plugin="pluginpages"><i class="material-icons" aria-hidden="true">check_circle</i>Plugin Pages detected</span></div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="downloadsUseCustomTabs" is="emby-checkbox" type="checkbox"/><span>Use Custom Tabs for Requests</span></label></div>
+
+                            <div class="checkboxContainer je-customtabs-automanage" data-gated-by="downloadsUseCustomTabs,downloadsPageEnabled">
+                                <label><input id="downloadsAutoCreateCustomTab" is="emby-checkbox" type="checkbox"/><span>Add the Custom Tabs entry for me</span></label>
+                            </div>
+                            <div class="je-setting-description je-customtabs-automanage" data-desc-for="downloadsAutoCreateCustomTab" data-gated-by="downloadsUseCustomTabs,downloadsPageEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Jellyfin Enhanced will create the matching Custom Tabs entry on save. Turning off "Use Custom Tabs for Requests" removes the entry; turning it back on re-creates it. Leave unchecked to manage the Custom Tabs entry yourself.
+                                </div>
+                            </div>
+
+                            <div class="je-setting-description" data-desc-for="downloadsUseCustomTabs">
+                                <div class="je-info-banner-inline">
+                                    <div class="je-info-banner-row">
+                                        <i class="material-icons je-info-icon">info</i>
                                         <div>
-                                            • Requests are triggered when users start or complete watching episodes<br>
-                                            • Set threshold to 2-3 episodes to give time for downloading before users finish watching<br>
-                                            • Example: With threshold set to 2, when user starts episode 8 of 10 of season 1, season 2 will be requested<br>
-                                            • If a user has already triggered a request for the season, it will not be requested again even if another user reaches the threshold<br>
+                                            <h4 class="je-custom-tabs-h4">
+                                                Embed Requests in Custom Tabs:
+                                                <span class="je-installed-badge" data-plugin="customtabs"><i class="material-icons" aria-hidden="true">check_circle</i>Custom Tabs detected</span>
+                                            </h4>
+                                            <p class="fieldDescription je-custom-tabs-p">Display the Requests page in a Custom Tabs tab instead of the sidebar link.</p>
+                                            <p class="fieldDescription je-custom-tabs-p-mt je-needs-customtabs">You need the <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs" target="_blank">Custom Tabs</a> plugin.</p>
+                                            <ol class="fieldDescription je-custom-tabs-ol">
+                                                <li class="je-custom-tabs-li je-needs-customtabs">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
+                                                <li class="je-custom-tabs-li">Navigate to Dashboard &gt; Plugins &gt; Custom Tabs and add a new tab.</li>
+                                                <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Requests")</li>
+                                                <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
+                                            </ol>
+                                            <div class="je-copy-code-wrapper">
+                                                <button class="je-copy-html-btn raised raised-mini emby-button" data-copy-text='&lt;div class="jellyfinenhanced requests"&gt;&lt;/div&gt;' type="button">
+                                                    <i class="material-icons je-copy-icon">content_copy</i>
+                                                    <span class="copy-btn-text je-copy-btn-text">Copy</span>
+                                                </button>
+                                                <pre class="je-code-pre"><code>&lt;div class="jellyfinenhanced requests"&gt;&lt;/div&gt;</code></pre>
+                                            </div>
+                                            <div class="fieldDescription je-field-desc-mt">
+                                                Already have Custom Tabs installed?
+                                                <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
+                                            </div>
                                         </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="downloadsPagePollingEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Auto-Refresh</span></label></div>
+                            <div class="je-setting-description" data-desc-for="downloadsPagePollingEnabled">
+                                <div class="fieldDescription">Periodically refresh the Requests page so download progress updates without manual reload.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="downloadsPollIntervalSeconds">Poll Interval (seconds)</label>
+                                <input id="downloadsPollIntervalSeconds" is="emby-input" type="number" min="30" max="300"/>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="downloadsPollIntervalSeconds">
+                                <div class="fieldDescription je-field-desc-xl">How often to refresh download status automatically. Minimum is 30 seconds and applies only when auto-refresh is enabled.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Calendar Page</legend>
+                        <div class="configSection">
+                            <div class="je-info-banner-inline-center" style="margin-bottom: 15px;">
+                                <div class="je-info-banner-row">
+                                    <i class="material-icons je-info-icon">calendar_today</i>
+                                    <div>
+                                        <strong>Calendar Page</strong> adds a Calendar Button in sidebar with a dedicated view that displays upcoming releases from Sonarr and Radarr in a calendar view.<br/><br/>
+                                        <strong>Requirements:</strong> Configure Sonarr and/or Radarr URLs and API keys.
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="calendarPageEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Calendar Page</span></label></div>
+                            <div class="je-setting-description" data-desc-for="calendarPageEnabled">
+                                <div class="fieldDescription je-field-desc-xl">Adds a "Calendar" link to the navigation showing upcoming releases from Sonarr/Radarr.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="calendarUsePluginPages" is="emby-checkbox" type="checkbox"/><span>Use Plugin Pages</span></label></div>
+                            <div class="je-setting-description" data-desc-for="calendarUsePluginPages">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    Replaces the default Calendar page with a <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-pages" target="_blank">Plugin Pages</a> implementation.<br/>
+                                    <strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.
+                                    <span class="je-installed-badge" data-plugin="pluginpages"><i class="material-icons" aria-hidden="true">check_circle</i>Plugin Pages detected</span>
+                                </div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="calendarUseCustomTabs" is="emby-checkbox" type="checkbox"/><span>Use Custom Tabs</span></label></div>
+
+                            <div class="checkboxContainer je-customtabs-automanage" data-gated-by="calendarUseCustomTabs,calendarPageEnabled">
+                                <label><input id="calendarAutoCreateCustomTab" is="emby-checkbox" type="checkbox"/><span>Add the Custom Tabs entry for me</span></label>
+                            </div>
+                            <div class="je-setting-description je-customtabs-automanage" data-desc-for="calendarAutoCreateCustomTab" data-gated-by="calendarUseCustomTabs,calendarPageEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Jellyfin Enhanced will create the matching Custom Tabs entry on save. Turning off "Use Custom Tabs" removes the entry; turning it back on re-creates it. Leave unchecked to manage the Custom Tabs entry yourself.
+                                </div>
+                            </div>
+
+                            <div class="je-setting-description" data-desc-for="calendarUseCustomTabs">
+                                <div class="je-info-banner-inline">
+                                    <div class="je-info-banner-row">
+                                        <i class="material-icons je-info-icon">info</i>
+                                        <div>
+                                            <h4 class="je-custom-tabs-h4">
+                                                Embed Calendar in Custom Tabs:
+                                                <span class="je-installed-badge" data-plugin="customtabs"><i class="material-icons" aria-hidden="true">check_circle</i>Custom Tabs detected</span>
+                                            </h4>
+                                            <p class="fieldDescription je-custom-tabs-p">Display the Calendar page in a Custom Tabs tab instead of the sidebar link.</p>
+                                            <p class="fieldDescription je-custom-tabs-p-mt je-needs-customtabs">You need the <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs" target="_blank">Custom Tabs</a> plugin.</p>
+                                            <ol class="fieldDescription je-custom-tabs-ol">
+                                                <li class="je-custom-tabs-li je-needs-customtabs">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
+                                                <li class="je-custom-tabs-li">Navigate to Dashboard &gt; Plugins &gt; Custom Tabs and add a new tab.</li>
+                                                <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Calendar").</li>
+                                                <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
+                                            </ol>
+                                            <div class="je-copy-code-wrapper">
+                                                <button class="je-copy-html-btn raised raised-mini emby-button" data-copy-text='&lt;div class="jellyfinenhanced calendar"&gt;&lt;/div&gt;' type="button">
+                                                    <i class="material-icons je-copy-icon">content_copy</i>
+                                                    <span class="copy-btn-text je-copy-btn-text">Copy</span>
+                                                </button>
+                                                <pre class="je-code-pre"><code>&lt;div class="jellyfinenhanced calendar"&gt;&lt;/div&gt;</code></pre>
+                                            </div>
+                                            <div class="fieldDescription je-field-desc-mt">
+                                                Already have Custom Tabs installed?
+                                                <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="calendarFirstDayOfWeek">First Day of Week</label>
+                                <select id="calendarFirstDayOfWeek" name="calendarFirstDayOfWeek" is="emby-select" class="emby-select">
+                                    <option value="Sunday">Sunday</option><option value="Monday">Monday</option><option value="Tuesday">Tuesday</option>
+                                    <option value="Wednesday">Wednesday</option><option value="Thursday">Thursday</option><option value="Friday">Friday</option><option value="Saturday">Saturday</option>
+                                </select>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="calendarFirstDayOfWeek">
+                                <div class="fieldDescription">Which day appears as the first column of the calendar grid.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="calendarTimeFormat">Time Format</label>
+                                <select id="calendarTimeFormat" name="calendarTimeFormat" is="emby-select" class="emby-select">
+                                    <option value="5pm/5:30pm">5pm/5:30pm</option><option value="17:00/17:30">17:00/17:30</option>
+                                </select>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="calendarTimeFormat">
+                                <div class="fieldDescription">Whether release times display in 12-hour (5pm) or 24-hour (17:00) format.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="calendarHighlightFavorites" is="emby-checkbox" type="checkbox"/><span>Highlight Favorites/Watchlist</span></label></div>
+                            <div class="je-setting-description" data-desc-for="calendarHighlightFavorites">
+                                <div class="fieldDescription je-field-desc-md">Show a golden border on calendar entries for items in your Jellyfin favorites.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="calendarHighlightWatchedSeries" is="emby-checkbox" type="checkbox"/><span>Highlight Watched Series</span></label></div>
+                            <div class="je-setting-description" data-desc-for="calendarHighlightWatchedSeries">
+                                <div class="fieldDescription">Show a border on calendar entries for series you have watched episodes from.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="calendarFilterByLibraryAccess" is="emby-checkbox" type="checkbox"/><span>Filter by Library Access</span></label></div>
+                            <div class="je-setting-description" data-desc-for="calendarFilterByLibraryAccess">
+                                <div class="fieldDescription">When enabled, the calendar only shows items from libraries the user has access to. Upcoming items not yet in Jellyfin are filtered based on their Sonarr/Radarr root folder.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="calendarShowOnlyRequested" is="emby-checkbox" type="checkbox"/><span>Show Requested Only (Default)</span></label></div>
+                            <div class="je-setting-description" data-desc-for="calendarShowOnlyRequested">
+                                <div class="fieldDescription">When enabled, the calendar will load showing only Requested items by default, but users can still change filters.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="calendarForceOnlyRequested" is="emby-checkbox" type="checkbox"/><span>Force Only Requested Items</span></label></div>
+                            <div class="je-setting-description" data-desc-for="calendarForceOnlyRequested">
+                                <div class="fieldDescription">When enabled, the calendar always shows only your requested items and the Requests filter is hidden.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div id="seerr" class="jellyfin-tab-content">
+                    <fieldset>
+                        <legend class="sectionTitle">Seerr Connection Setup</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer">
+                                <label><input id="jellyseerrEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Seerr integration</span></label>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrEnabled">
+                                <div class="fieldDescription je-field-desc-xl">Enables all Seerr-powered features for this server: Seerr search results, request buttons, the Requests page, auto-requests, and user import. Required for any Seerr feature to work.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="jellyseerrUrls">Seerr URL(s) <span style="font-size:0.8em; opacity:0.6;">(One per line)</span></label>
+                                <textarea class="emby-textarea emby-input je-textarea-medium" id="jellyseerrUrls" name="jellyseerrUrls" placeholder="http://192.168.1.10:5055&#10;https://jellyseerr.example.com"></textarea>
+                            </div>
+                                <div class="je-setting-description" data-desc-for="jellyseerrUrls">
+                                    <div class="fieldDescription">Enter your Seerr instance URLs, one per line. The script will use the first one that connects successfully.</div>
+                                </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="JellyseerrApiKey">Seerr API Key</label>
+                                <div class="je-api-row">
+                                    <input id="JellyseerrApiKey" is="emby-input" name="JellyseerrApiKey" type="password" class="je-api-input"/>
+                                    <span id="jellyseerrStatusIndicator" class="material-icons"></span>
+                                    <button is="emby-button" type="button" id="testJellyseerrBtn" class="emby-button raised button-submit">Test</button>
+                                </div>
+                            </div>
+                                    <div class="je-setting-description" data-desc-for="JellyseerrApiKey">
+                                        <div class="fieldDescription">API key from Seerr. (Settings &gt; General Settings &gt;  API Key)</div>
+                                    </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="jellyseerr_TMDB_API_KEY">TMDB API Key</label>
+                                <div class="je-api-row">
+                                    <input id="jellyseerr_TMDB_API_KEY" is="emby-input" name="TMDB_API_KEY" type="password" class="je-api-input"/>
+                                    <span id="jellyseerrTmdbStatusIndicator" class="material-icons"></span>
+                                    <button is="emby-button" type="button" class="testTmdbBtn emby-button raised button-submit">Test</button>
+                                </div>
+                            </div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerr_TMDB_API_KEY">
+                                        <div class="fieldDescription">Your API key from The Movie DB (TMDB). <a class="sectionTitle" href="https://www.themoviedb.org/settings/api" target="_blank">How to?</a><br/>TMDB API key for automatic movie collection requests and Seerr Collection Results. Shared with Elsewhere Settings</div>
+                                    </div>
+
+                            <details class="je-details-section">
+                                <summary>Advanced URL Mappings</summary>
+                                <div class="je-details-body">
+                                    <div class="inputContainer">
+                                        <label class="inputLabel je-seerr-label" for="jellyseerrUrlMappings">Seerr URL Mappings</label>
+                                        <textarea class="emby-textarea emby-input je-textarea-medium" id="jellyseerrUrlMappings" name="jellyseerrUrlMappings" placeholder="https://jellyfin.mydomain.com|https://jellyseerr.mydomain.com"></textarea>
+                                    </div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrUrlMappings">
+                                        <div class="fieldDescription">
+                                            Map your Jellyfin URLs to specific Seerr URLs for displaying links to users. Users will get the appropriate Seerr link when using "Link result titles to Seerr instead of TMDB", based on what link they use to access Jellyfin.<br/>
+                                            Format: <code>JellyfinURL|SeerrURL</code>, one mapping per line.<br/>
+                                            If no mapping matches or this is empty, the first URL from above will be used.
+                                        </div>
+                                        <div class="je-info-banner-inline">
+                                            <i class="material-icons je-info-icon-sm">info</i>
+                                            <div>
+                                                <strong>URL Mapping Examples:</strong><br/>
+                                                • Remote access: <code>https://jellyfin.mydomain.com|https://jellyseerr.mydomain.com</code><br/>
+                                                • Local access: <code>http://192.168.1.10:8096|http://192.168.1.10:5055</code><br/>
+                                                • With base URL: <code>https://example.com/jellyfin|https://example.com/jellyseerr</code>
+                                            </div>
+                                        </div>
+                                        <div class="je-mobile-banner">
+                                            <i class="material-icons je-mobile-icon">phone_android</i>
+                                            <div>Make sure proper mappings are added to appropriate URLs in order for mobile clients to open Seerr links correctly.</div>
+                                        </div>
+                                        <div class="je-info-banner-inline-center">
+                                            <i class="material-icons je-info-icon-sm">info</i>
+                                            <div>
+                                                "<b>Enable Jellyfin Sign-In</b>" must be enabled in Seerr User Settings (/settings/users)<br/><br/>
+                                                All users must be imported to Seerr as Jellyfin users for them to be able to request content.
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button is="emby-button" type="button" id="validateSeerrMappingsBtn" class="raised button-submit emby-button" style="width:fit-content;">Validate Mappings</button>
+                                    <div id="seerrMappingsValidationResult" style="display: none;"></div>
+                                </div>
+                            </details>
+
+                            <div class="je-purple-banner">
+                                <i class="material-icons je-purple-icon">favorite</i>
+                                <div style="font-size: 0.9em;">
+                                    <b>Jellyfin Enhanced is not affiliated with Seerr.</b><br/>
+                                    Seerr is an independent project. This plugin only uses Seerr's public API to integrate request and discovery features into Jellyfin.<br/>
+                                    Please report plugin issues to the <a class="sectionTitle" href="https://github.com/n00bcodr/Jellyfin-Enhanced/issues" target="_blank">Jellyfin Enhanced issue tracker</a>, not the Seerr team.
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Search &amp; Requests</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="jellyseerrShowSearchResults" is="emby-checkbox" type="checkbox"/><span>Show Seerr Results in Search</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrShowSearchResults">
+                                <div class="fieldDescription je-field-desc-xl">Enhance Jellyfin search by showing results from Seerr.<br/>This allows users to discover and request missing movies and shows directly from Jellyfin.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="showCollectionsInSearch" is="emby-checkbox" type="checkbox"/><span>Show Collections in Seerr Results</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showCollectionsInSearch">
+                                <div class="fieldDescription je-field-desc-xl">Display TMDB collections (e.g., Harry Potter, Marvel Cinematic Universe) in Seerr search results with an option to request the entire collection at once.<br/><br/><b>Requires TMDB API Key to be configured.</b></div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="jellyseerrEnable4kRequests" is="emby-checkbox" type="checkbox"/><span>Enable 4K Requests</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrEnable4kRequests">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, movie request buttons include a dropdown to request a 4K version.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="jellyseerrEnable4kTvRequests" is="emby-checkbox" type="checkbox"/><span>Enable 4K TV Requests</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrEnable4kTvRequests">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, TV request buttons include a dropdown that opens the season request modal in 4K mode.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="jellyseerrShowAdvanced" is="emby-checkbox" type="checkbox"/><span>Show advanced request options</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrShowAdvanced">
+                                <div class="fieldDescription je-field-desc-xl">Enable this if you want users to be able to choose between Servers, Quality and Paths while requesting. <br/> Note: This will disregard any Override Rules set in Seerr.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Discovery &amp; UI Extras</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="jellyseerrUseMoreInfoModal" is="emby-checkbox" type="checkbox"/><span>Open results in "More Info" modal</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrUseMoreInfoModal">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, clicking a Seerr result title or poster opens an in-app More Info modal.<br/>When disabled, clicking will open the item in Seerr.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="jellyseerrShowReportButton" is="emby-checkbox" type="checkbox"/><span>Show "Report Issue" button on items</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrShowReportButton">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, a small report icon will be added to item action icons allowing users to report playback/content issues to Seerr.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="jellyseerrShowIssueIndicator" is="emby-checkbox" type="checkbox"/><span>Show open issue indicator</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrShowIssueIndicator">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, the report issue button turns orange and shows a count badge if the item has open issues in Seerr.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="showElsewhereOnJellyseerr" is="emby-checkbox" type="checkbox"/><span>Show Streaming Providers on Posters</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showElsewhereOnJellyseerr">
+                                <div class="fieldDescription je-field-desc-xl">Displays icons of available streaming services (from your default region) on Seerr Posters.<br/><br/><b>Requires TMDB API Key to be configured in Elsewhere Settings</b></div>
+                            </div>
+
+                            <details class="je-details-section">
+                                <summary>Item Pages Discovery</summary>
+                                <div class="je-details-body">
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowSimilar" is="emby-checkbox" type="checkbox"/><span>Show similar items</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowSimilar">
+                                        <div class="fieldDescription je-field-desc-xl">Displays similar movies/shows from Seerr on item details pages. Limited to 20 items.</div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowRecommended" is="emby-checkbox" type="checkbox"/><span>Show recommended items</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowRecommended">
+                                        <div class="fieldDescription je-field-desc-xl">Displays recommended movies/shows from Seerr on item details pages. Limited to 20 items.</div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowRequestMoreOnSeries" is="emby-checkbox" type="checkbox"/><span>Show "Request More" button on Series</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowRequestMoreOnSeries">
+                                        <div class="fieldDescription je-field-desc-xl">Adds a "Request More" button beside the Seasons section heading on Series detail pages when the show has unrequested seasons in Seerr. Lets users request additional seasons without going through the search bar.</div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrExcludeLibraryItems" is="emby-checkbox" type="checkbox"/><span>Exclude items already in library</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrExcludeLibraryItems">
+                                        <div class="fieldDescription je-field-desc-xl">Hide similar/recommended items that already exist in your Jellyfin library from the results.<br/>If disabled, the items that are available link to the media item in the library.</div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrExcludeBlocklistedItems" is="emby-checkbox" type="checkbox"/><span>Exclude blocklisted items</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrExcludeBlocklistedItems">
+                                        <div class="fieldDescription je-field-desc-xl">When enabled, items marked as blocklisted in Seerr will not appear in similar/recommended suggestions.</div>
                                     </div>
                                 </div>
                             </details>
 
                             <details class="je-details-section">
-                                <summary class="je-details-section-summary">Movie Collection Requests</summary>
+                                <summary>"More" Discovery</summary>
                                 <div class="je-details-body">
-                                    <div class="checkboxContainer">
-                                        <label>
-                                            <input id="autoMovieRequestEnabled" is="emby-checkbox" type="checkbox"/>
-                                            <span>Enable Automatic Movie Requests</span>
-                                        </label>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowNetworkDiscovery" is="emby-checkbox" type="checkbox"/><span>Show "More from Network"</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowNetworkDiscovery">
+                                        <div class="fieldDescription je-field-desc-md">When viewing a network page (e.g., Netflix, HBO), displays additional content from that network available in Seerr.</div>
                                     </div>
-                                    <div class="fieldDescription je-field-desc-xl">
-                                        Automatically request the next movie in a collection based on configured triggers.
-                                        <br><br>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowGenreDiscovery" is="emby-checkbox" type="checkbox"/><span>Show "More Genre"</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowGenreDiscovery">
+                                        <div class="fieldDescription je-field-desc-md">When viewing a genre page (e.g., Action, Comedy), displays additional content in that genre from Seerr.</div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowTagDiscovery" is="emby-checkbox" type="checkbox"/><span>Show "More Tag"</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowTagDiscovery">
+                                        <div class="fieldDescription je-field-desc-md">When viewing a tag page (e.g., cooking, superhero), displays additional content with that keyword from Seerr.</div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowPersonDiscovery" is="emby-checkbox" type="checkbox"/><span>Show "More from Actor"</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowPersonDiscovery">
+                                        <div class="fieldDescription je-field-desc-md">When viewing an actor/person page, displays their filmography from Seerr including content not in your library.</div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="jellyseerrShowCollectionDiscovery" is="emby-checkbox" type="checkbox"/><span>Show missing collection movies</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="jellyseerrShowCollectionDiscovery">
+                                        <div class="fieldDescription je-field-desc-xl">When viewing a collection/BoxSet page, shows movies from the collection that are not yet in your library with request buttons.</div>
+                                    </div>
+                                </div>
+                            </details>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Automatic Requests</legend>
+                        <div class="configSection">
+                            <details class="je-details-section">
+                                <summary>Auto Season Requests</summary>
+                                <div class="je-details-body">
+                                    <div class="checkboxContainer"><label><input id="autoSeasonRequestEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Automatic Advance Season Requests</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="autoSeasonRequestEnabled">
+                                        <div class="fieldDescription je-field-desc-xl">
+                                            Automatically request the next season in Seerr when a user about to finish the current season.
+                                            <br/><br/>
+                                        </div>
+                                    </div>
+                                    <div class="checkboxContainer"><label><input id="autoSeasonRequestRequireAllWatched" is="emby-checkbox" type="checkbox"/><span>Require All Prior Episodes Watched</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="autoSeasonRequestRequireAllWatched">
+                                        <div class="fieldDescription je-field-desc-xl">
+                                            Require all episodes before the threshold to be watched. For example, if threshold is 2 and there are 10 episodes, when watching episode 8, all episodes 1-7 must be watched or marked as watched. This prevents accidentally triggering requests by jumping to later episodes. <br/> This might cause requests to not be triggered if users skip episodes.
+                                        </div>
+                                    </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel" for="autoSeasonRequestThresholdValue">Episodes Remaining Threshold</label>
+                                        <input id="autoSeasonRequestThresholdValue" is="emby-input" name="autoSeasonRequestThresholdValue" type="number" min="1" max="20" value="2"/>
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="autoSeasonRequestThresholdValue">
+                                            <div class="fieldDescription">Request the next season when the number of unwatched episodes is at or below this number. Default: 2 episodes.</div>
+                                            <div class="je-info-banner-inline">
+                                            <i class="material-icons je-info-icon-sm">info</i>
+                                            <div>
+                                                • Requests are triggered when users start or complete watching episodes<br/>
+                                                • Set threshold to 2-3 episodes to give time for downloading before users finish watching<br/>
+                                                • Example: With threshold set to 2, when user starts episode 8 of 10 of season 1, season 2 will be requested<br/>
+                                                • If a user has already triggered a request for the season, it will not be requested again even if another user reaches the threshold<br/>
+                                            </div>
+                                            </div>
+                                        </div>
+                                </div>
+                            </details>
+
+                            <details class="je-details-section">
+                                <summary>Auto Movie Requests</summary>
+                                <div class="je-details-body">
+                                    <div class="checkboxContainer"><label><input id="autoMovieRequestEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Auto Movie Requests</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="autoMovieRequestEnabled">
+                                        <div class="fieldDescription je-field-desc-xl">
+                                            Automatically request the next movie in a collection based on configured triggers.
+                                            <br/><br/>
                                         <strong>Requirements:</strong> TMDB API key must be configured.
+                                        </div>
                                     </div>
 
-                                    <div class="je-trigger-section">
-                                        <label class="je-trigger-label">Request Triggers:</label>
-                                        <div class="checkboxContainer je-checkbox-mb-075">
-                                            <label>
-                                                <input id="autoMovieRequestTriggerOnStart" is="emby-checkbox" type="checkbox"/>
-                                                <span>When movie starts (within first 5 minutes)</span>
-                                            </label>
-                                        </div>
-                                        <div class="checkboxContainer je-checkbox-mb-075">
-                                            <label>
-                                                <input id="autoMovieRequestTriggerOnMinutesWatched" is="emby-checkbox" type="checkbox"/>
-                                                <span>After watching for a certain amount of time</span>
-                                            </label>
-                                        </div>
+                                    <div style="margin-top:10px;"><strong>Request Triggers:</strong></div>
+                                    <div class="checkboxContainer"><label><input id="autoMovieRequestTriggerOnStart" is="emby-checkbox" type="checkbox"/><span>When movie starts</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="autoMovieRequestTriggerOnStart">
+                                        <div class="fieldDescription je-field-desc-mt-sm">Trigger an auto-request for the next movie in the collection as soon as a user starts a movie.</div>
+                                    </div>
+
+                                    <div class="checkboxContainer"><label><input id="autoMovieRequestTriggerOnMinutesWatched" is="emby-checkbox" type="checkbox"/><span>After X minutes watched</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="autoMovieRequestTriggerOnMinutesWatched">
                                         <div class="fieldDescription je-field-desc-mt-sm">
                                             Select one or both triggers. If both are selected, the request will be triggered if either condition is met.
                                         </div>
                                     </div>
 
-                                    <div class="je-trigger-section">
-                                        <label for="autoMovieRequestMinutesWatched" class="je-trigger-label">Minutes Watched Before Auto-Request Check:</label>
-                                        <input id="autoMovieRequestMinutesWatched" type="text" pattern="[0-9]+" class="je-minutes-input" value="20" />
-                                        <span class="je-minutes-label">minutes</span>
+                                    <div class="inputContainer">
+                                        <label for="autoMovieRequestMinutesWatched" class="inputLabel">Minutes Watched Threshold:</label>
+                                        <input id="autoMovieRequestMinutesWatched" is="emby-input" type="number" min="1" max="180" value="20" />
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="autoMovieRequestMinutesWatched">
+                                            <div class="fieldDescription je-field-desc-mt-sm">
+                                                How many minutes a user should watch before triggering a request? Must be between 1 and 180 minutes.
+                                            </div>
+                                        </div>
+
+                                    <div class="checkboxContainer"><label><input id="autoMovieRequestCheckReleaseDate" is="emby-checkbox" type="checkbox"/><span>Only request if released</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="autoMovieRequestCheckReleaseDate">
                                         <div class="fieldDescription je-field-desc-mt-sm">
-                                            How many minutes a user should watch before triggering a request? Must be between 1 and 180 minutes.
+                                            When enabled, future releases will be skipped. Only movies that have already been released will be requested.
                                         </div>
                                     </div>
 
-                                    <div class="checkboxContainer je-checkbox-mb-15">
-                                        <label>
-                                            <input id="autoMovieRequestCheckReleaseDate" is="emby-checkbox" type="checkbox"/>
-                                            <span>Only request if movie is already released</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-mt-sm">
-                                        When enabled, future releases will be skipped. Only movies that have already been released will be requested.
-                                    </div>
-
-                                    <div class="je-quality-mode-section">
-                                        <label for="autoMovieRequestQualityMode" class="je-custom-settings-label">Quality Profile Mode:</label>
+                                    <div class="inputContainer">
+                                        <label for="autoMovieRequestQualityMode" class="inputLabel">Quality Profile Mode:</label>
                                         <select id="autoMovieRequestQualityMode" is="emby-select" class="emby-select">
-                                            <option value="default">Default (Seerr decides)</option>
-                                            <option value="original">Original (copy from watched movie)</option>
-                                            <option value="custom">Custom (select specific profile)</option>
+                                            <option value="default">Default</option><option value="original">Original</option><option value="custom">Custom</option>
                                         </select>
-                                        <div class="fieldDescription je-field-desc-mt-sm">
-                                            <strong>Default:</strong> Seerr uses its default Radarr server and quality profile.<br>
-                                            <strong>Original:</strong> Uses the same quality profile as the movie being watched (falls back to default if not found).<br>
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="autoMovieRequestQualityMode">
+                                            <div class="fieldDescription je-field-desc-mt-sm">
+                                            <strong>Default:</strong> Seerr uses its default Radarr server and quality profile.<br/>
+                                            <strong>Original:</strong> Uses the same quality profile as the movie being watched (falls back to default if not found).<br/>
                                             <strong>Custom:</strong> Always uses the specific Radarr server, quality profile, and root folder selected below.
+                                            </div>
+                                        </div>
+
+                                    <div class="checkboxContainer"><label><input id="autoMovieRequestFallbackOn4k" is="emby-checkbox" type="checkbox"/><span>Use default instead of 4K fallback</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="autoMovieRequestFallbackOn4k">
+                                        <div class="fieldDescription je-field-desc-lg">
+                                            Only applies when Quality Profile Mode is set to "Original". If the watched movie was requested with a 4K profile, the auto-request will use Seerr's default profile instead. This prevents requests from failing or requiring manual approval for users who don't have 4K request permissions in Seerr. Disable this if all your users have 4K request access and you want to preserve the original 4K profile.
                                         </div>
                                     </div>
 
-                                    <div class="checkboxContainer">
-                                        <label class="je-elsewhere-label">
-                                            <input id="autoMovieRequestFallbackOn4k" is="emby-checkbox" type="checkbox" checked/>
-                                            <span>Use default profile instead of 4K for users without 4K request access</span>
-                                        </label>
-                                    </div>
-                                    <div class="fieldDescription je-field-desc-lg">
-                                        Only applies when Quality Profile Mode is set to "Original". If the watched movie was requested with a 4K profile, the auto-request will use Seerr's default profile instead. This prevents requests from failing or requiring manual approval for users who don't have 4K request permissions in Seerr. Disable this if all your users have 4K request access and you want to preserve the original 4K profile.
-                                    </div>
-
-                                    <div id="autoMovieRequestCustomSettings" style="display: none;">
-                                        <div class="je-custom-settings-row">
-                                            <label for="autoMovieRequestServer" class="je-custom-settings-label">Radarr Server:</label>
-                                            <select id="autoMovieRequestServer" is="emby-select" class="emby-select">
-                                                <option value="-1">Select Server...</option>
-                                            </select>
-                                        </div>
-                                        <div class="je-custom-settings-row">
-                                            <label for="autoMovieRequestProfile" class="je-custom-settings-label">Quality Profile:</label>
-                                            <select id="autoMovieRequestProfile" is="emby-select" class="emby-select">
-                                                <option value="0">Select a server first...</option>
-                                            </select>
-                                        </div>
-                                        <div class="je-custom-settings-row">
-                                            <label for="autoMovieRequestRootFolder" class="je-custom-settings-label">Root Folder:</label>
-                                            <select id="autoMovieRequestRootFolder" is="emby-select" class="emby-select">
-                                                <option value="">Select a server first...</option>
-                                            </select>
-                                        </div>
-                                        <div class="fieldDescription je-field-desc-mt-sm">
-                                            These settings are only used when Quality Profile Mode is set to "Custom".
-                                        </div>
-                                    </div>
-                                    <div
-                                        class="je-info-banner-inline">
-                                        <i class="material-icons je-info-icon-sm">info</i>
-                                        <div>
-                                            • Only works for movies that are part of a TMDB collection (e.g., <a href="https://www.themoviedb.org/collection/86311" target="_blank" class="je-bold-link">The Avengers Collection</a>, <a href="https://www.themoviedb.org/collection/10" target="_blank" class="je-bold-link">Star Wars Collection</a>, etc.)<br>
-                                            • Automatically requests the next movie in the collection based on release order<br>
-                                            • Movies already available or requested will be skipped<br>
+                                    <div id="autoMovieRequestCustomSettings" style="display:none; background: rgba(0,0,0,0.2); padding: 10px; border-radius: 8px;">
+                                        <div class="inputContainer"><label class="inputLabel" for="autoMovieRequestServer">Radarr Server:</label><select id="autoMovieRequestServer" name="autoMovieRequestServer" is="emby-select" class="emby-select"></select></div>
+                                        <div class="inputContainer"><label class="inputLabel" for="autoMovieRequestProfile">Quality Profile:</label><select id="autoMovieRequestProfile" name="autoMovieRequestProfile" is="emby-select" class="emby-select"></select></div>
+                                        <div class="inputContainer"><label class="inputLabel" for="autoMovieRequestRootFolder">Root Folder:</label><select id="autoMovieRequestRootFolder" name="autoMovieRequestRootFolder" is="emby-select" class="emby-select"></select></div>
+                                        <div class="je-setting-description" data-desc-for="autoMovieRequestRootFolder">
+                                            <div class="fieldDescription je-field-desc-mt-sm">
+                                                These settings are only used when Quality Profile Mode is set to "Custom".
+                                            </div>
+                                            <div class="je-info-banner-inline">
+                                            <i class="material-icons je-info-icon-sm">info</i>
+                                            <div>
+                                                • Only works for movies that are part of a TMDB collection (e.g., <a class="je-bold-link" href="https://www.themoviedb.org/collection/86311" target="_blank">The Avengers Collection</a>, <a class="je-bold-link" href="https://www.themoviedb.org/collection/10" target="_blank">Star Wars Collection</a>, etc.)<br/>
+                                                • Automatically requests the next movie in the collection based on release order<br/>
+                                                • Movies already available or requested will be skipped<br/>
+                                            </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </details>
                         </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Watchlist Integration</h3></legend>
+
+<fieldset>
+                        <legend class="sectionTitle">Watchlist</legend>
                         <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="addRequestedMediaToWatchlist" is="emby-checkbox" type="checkbox"/>
-                                    <span>Automatically add requested media to user's Watchlist</span>
-                                </label>
+                            <div class="checkboxContainer"><label><input id="addRequestedMediaToWatchlist" is="emby-checkbox" type="checkbox"/><span>Add requested media to Watchlist</span></label></div>
+                            <div class="je-setting-description" data-desc-for="addRequestedMediaToWatchlist">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    When enabled, any media requested through Seerr Search via Jellyfin Enhanced will automatically be added to the requesting user's Watchlist.<br/><br/>
+                                    <strong>Note:</strong> Requires <a class="je-bold-link" href="https://github.com/ranaldsgift/KefinTweaks" target="_blank">KefinTweaks</a> to be installed to actually view the watchlisted items.
+                                    <span class="je-installed-badge" data-plugin="kefintweaks"><i class="material-icons" aria-hidden="true">check_circle</i>KefinTweaks detected</span>
+                                </div>
                             </div>
-                            <div class="fieldDescription je-field-desc-xl">
-                                When enabled, any media requested through Seerr Search through Jellyfin Enhanced will automatically be added to the requesting user's Watchlist.
-                                <br><br>
-                                <strong>Note:</strong> This feature requires <a class="sectionTitle" target="_blank" href="https://github.com/ranaldsgift/KefinTweaks" class="je-bold-link">KefinTweaks</a> to be installed to actually view the watchlisted items.
+
+                            <div class="checkboxContainer"><label><input id="syncJellyseerrWatchlist" is="emby-checkbox" type="checkbox"/><span>Sync Seerr Watchlist</span></label></div>
+                            <div class="je-setting-description" data-desc-for="syncJellyseerrWatchlist">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    When enabled, items from each user's Seerr watchlist will be automatically synced to their Jellyfin watchlist.<br/><br/>
+                                    Configure how often the sync should run in Jellyfin Dashboard &gt; Scheduled Tasks &gt; "Sync Watchlist from Seerr to Jellyfin".<br/><br/>
+                                    <strong>Note:</strong> Requires <a class="je-bold-link" href="https://github.com/ranaldsgift/KefinTweaks" target="_blank">KefinTweaks</a> to actually render the watchlist UI.
+                                    <span class="je-installed-badge" data-plugin="kefintweaks"><i class="material-icons" aria-hidden="true">check_circle</i>KefinTweaks detected</span>
+                                </div>
                             </div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="syncJellyseerrWatchlist" is="emby-checkbox" type="checkbox"/>
-                                    <span>Sync Seerr Watchlist to Jellyfin</span>
-                                </label>
+
+                            <div class="checkboxContainer"><label><input id="preventWatchlistReAddition" is="emby-checkbox" type="checkbox"/><span>Prevent re-adding removed items</span></label></div>
+                            <div class="je-setting-description" data-desc-for="preventWatchlistReAddition">
+                                <div class="fieldDescription je-field-desc-md">
+                                    When enabled, items will only be added to a user's watchlist once. If a user manually removes an item from their watchlist, it won't be automatically re-added during future sync runs.
+                                </div>
                             </div>
-                            <div class="fieldDescription je-field-desc-xl">
-                                When enabled, items from each user's Seerr watchlist will be automatically synced to their Jellyfin watchlist. <br><br>
-                                Configure how often the sync should run in Jellyfin Dashboard &gt; Scheduled Tasks &gt; "Sync Watchlist from Seerr to Jellyfin".
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="watchlistMemoryRetentionDays">Memory retention (days):</label>
+                                <input id="watchlistMemoryRetentionDays" is="emby-input" type="number" min="1" max="3650" step="1"/>
                             </div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="preventWatchlistReAddition" is="emby-checkbox" type="checkbox"/>
-                                    <span>Prevent re-adding removed watchlist items</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                When enabled, items will only be added to a user's watchlist once. If a user manually removes an item from their watchlist, it won't be automatically re-added during future sync runs.
-                            </div>
-                            <div class="inputContainer je-input-mb-sm">
-                                <label class="inputLabel inputLabelUnfocused" for="watchlistMemoryRetentionDays">Memory retention period (days):</label>
-                                <input id="watchlistMemoryRetentionDays" is="emby-input" type="number" min="1" max="3650" step="1" class="je-retention-input"/>
+                            <div class="je-setting-description" data-desc-for="watchlistMemoryRetentionDays">
                                 <div class="fieldDescription je-field-desc-mt-sm je-field-desc-md">
-                                    How long to remember that an item was processed before allowing it to be re-added.<br>After this period, manually removed items (if unwatched) will be automatically re-added to watchlist if they're still in Seerr requests or Seerr watchlist.
-                                    <br><br>
+                                    How long to remember that an item was processed before allowing it to be re-added.<br/>After this period, manually removed items (if unwatched) will be automatically re-added to watchlist if they're still in Seerr requests or Seerr watchlist.<br/><br/>
                                     <strong>Examples:</strong>
                                     <ul class="je-retention-list">
-                                        <li><strong>30 days</strong> - Short memory, items can be re-added after 1 month</li>
-                                        <li><strong>365 days</strong> - Remember for 1 year (recommended)</li>
-                                        <li><strong>3650 days</strong> - Remember for 10 years (nearly permanent)</li>
+                                        <li><strong>30 days</strong> — Short memory, items can be re-added after 1 month</li>
+                                        <li><strong>365 days</strong> — Remember for 1 year (recommended)</li>
+                                        <li><strong>3650 days</strong> — Remember for 10 years (nearly permanent)</li>
                                     </ul>
-                                    <strong>Note:</strong> This setting only applies when "Prevent re-adding removed watchlist items" is enabled.
+                                    <strong>Note:</strong> This setting only applies when "Prevent re-adding removed items" is enabled.
                                 </div>
                             </div>
                         </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>User Import</h3></legend>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Users</legend>
                         <div class="configSection">
-                            <div class="fieldDescription je-field-desc-lg">
-                                Automatically import Jellyfin users into Seerr so they can use Seerr Search without needing to visit Seerr directly.
+                            <div class="checkboxContainer"><label><input id="jellyseerrAutoImportUsers" is="emby-checkbox" type="checkbox"/><span>Auto import Jellyfin users to Seerr</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrAutoImportUsers">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    Automatically import Jellyfin users into Seerr so they can use Seerr Search without needing to visit Seerr directly. New users are imported the first time they use Seerr Search; a scheduled task also bulk-imports periodically. Already-imported users are skipped.<br/><br/>
+                                    Configure the bulk import frequency in Jellyfin Dashboard &gt; Scheduled Tasks &gt; "Import Jellyfin Users to Seerr".
+                                </div>
                             </div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="jellyseerrAutoImportUsers" is="emby-checkbox" type="checkbox"/>
-                                    <span>Auto import Jellyfin users to Seerr</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">
-                                When enabled, new Jellyfin users are automatically imported into Seerr the first time they use Seerr Search. A scheduled task also runs periodically to bulk import all users. Already imported users are automatically skipped.
-                                <br><br>
-                                Configure the bulk import frequency in Jellyfin Dashboard &gt; Scheduled Tasks &gt; "Import Jellyfin Users to Seerr".
-                            </div>
-                            <div class="je-field-desc-xl">
-                                <details id="blockedUsersDetails" class="je-details-section">
-                                    <summary class="je-details-section-summary">Blocked users <span id="blockedUsersCount" class="je-blocked-count">(none)</span></summary>
-                                    <div class="fieldDescription je-field-desc-mt-sm je-field-desc-sm">
+
+                            <details id="blockedUsersDetails" class="je-details-section">
+                                <summary>Blocked Users <span id="blockedUsersCount">(none)</span></summary>
+                                <div class="je-details-body">
+                                    <div class="fieldDescription je-field-desc-md">
                                         Select users to exclude from Seerr import. Blocked users will never be looked up or imported. No API calls are made for them.
                                     </div>
-                                    <div id="blockedUsersContainer">
+                                    <div id="blockedUsersContainer" style="max-height: 200px; overflow-y: auto;">
                                         <span class="je-loading-text">Loading users...</span>
                                     </div>
                                     <div id="blockedUsersScrollHint" style="display: none;">▼ scroll for more</div>
-                                </details>
-                                <input id="jellyseerrImportBlockedUsers" type="hidden" value=""/>
-                            </div>
-                            <div class="je-field-desc-md">
-                                <button id="btnImportJellyseerrUsers" is="emby-button" type="button" class="raised button-submit block je-import-btn">
-                                    Import Users Now
-                                </button>
-                                <div id="importUsersResult" class="fieldDescription je-field-desc-mt" style="display: none;"></div>
-                            </div>
+                                </div>
+                            </details>
+                            <input id="jellyseerrImportBlockedUsers" type="hidden" value=""/>
+
+                            <button id="btnImportJellyseerrUsers" is="emby-button" type="button" class="raised button-submit emby-button" style="width: fit-content;">Import Users Now</button>
+                            <div id="importUsersResult" style="display: none; margin-top:10px;"></div>
                         </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Permission Audit</h3></legend>
+
+                    <fieldset>
+                        <legend class="sectionTitle">Permission Audit</legend>
                         <div class="configSection">
-                            <div class="fieldDescription je-field-desc-md">
-                                Check which users are missing Seerr permissions required for the features you have enabled. Only users linked to a Seerr account are checked.
+                            <div class="je-setting-description" data-desc-for="btnPermissionAudit">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Check which users are missing Seerr permissions required for the features you have enabled. Only users linked to a Seerr account are checked.
+                                </div>
                             </div>
-                            <button id="btnPermissionAudit" is="emby-button" type="button" class="raised button-submit emby-button">
+                            <button id="btnPermissionAudit" is="emby-button" type="button" class="raised button-submit emby-button" style="width: fit-content;">
                                 <span>Run Audit</span>
                             </button>
                             <div id="permissionAuditResult" style="display: none; margin-top: 1em;"></div>
                         </div>
                     </fieldset>
-                </div>
-                <div id="arr-links" class="jellyfin-tab-content">
 
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Configuration</h3></legend>
+                    <fieldset>
+                        <legend class="sectionTitle">Debug</legend>
                         <div class="configSection">
-                            <div class="fieldDescription je-field-desc-md">Configure one or more Sonarr instances. Each instance needs a URL and API key. The name helps identify instances when multiple are configured.</div>
+                            <div class="checkboxContainer"><label><input id="jellyseerrDisableCache" is="emby-checkbox" type="checkbox"/><span>Disable server-side response cache</span></label></div>
+                            <div class="je-setting-description" data-desc-for="jellyseerrDisableCache">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, all Seerr proxy requests bypass the server-side cache and are fetched fresh from Seerr every time. This is useful for testing but will increase load on your Seerr instance. <b>Not recommended for normal use.</b></div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="jellyseerrResponseCacheTtlMinutes">Response Cache TTL (min)</label>
+                                <input id="jellyseerrResponseCacheTtlMinutes" is="emby-input" type="number" min="1" value="10"/>
+                            </div>
+                                <div class="je-setting-description" data-desc-for="jellyseerrResponseCacheTtlMinutes">
+                                    <div class="fieldDescription">How long Seerr API responses (search, discovery, recommendations) are cached. Default: 10 minutes.</div>
+                                </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="jellyseerrUserIdCacheTtlMinutes">User ID Cache TTL (min)</label>
+                                <input id="jellyseerrUserIdCacheTtlMinutes" is="emby-input" type="number" min="1" value="30"/>
+                            </div>
+                                <div class="je-setting-description" data-desc-for="jellyseerrUserIdCacheTtlMinutes">
+                                    <div class="fieldDescription">How long the Jellyfin → Seerr user ID mapping is cached. Default: 30 minutes.</div>
+                                </div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div id="arr" class="jellyfin-tab-content">
+                    <div class="je-info-banner je-fieldset-wide je-tab-intro">
+                        <i class="material-icons je-info-icon">download_for_offline</i>
+                        <div>
+                            Connect Jellyfin Enhanced to your <strong>Sonarr</strong>, <strong>Radarr</strong>, and <strong>Bazarr</strong> instances. Each service gets its own box below — add as many Sonarr/Radarr instances as you want (one per quality profile / library), plus a single Bazarr endpoint. Each instance can be enabled, disabled, or removed independently.
+                        </div>
+                    </div>
+
+                    <fieldset>
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">tv</i>Sonarr</legend>
+                        <div class="configSection">
+                            <div class="je-setting-description" data-desc-for="sonarrInstancesList">
+                                <div class="fieldDescription">TV-show-focused *arr service. Add one instance per Sonarr server.</div>
+                            </div>
                             <div id="sonarrInstancesList"></div>
-                            <button id="addSonarrInstance" class="emby-button raised arr-add-btn" type="button">+ Add Sonarr Instance</button>
-                            <hr class="je-arr-hr">
-                            <div class="fieldDescription je-field-desc-md">Configure one or more Radarr instances. Each instance needs a URL and API key.</div>
+                            <div class="je-arr-action-row">
+                                <button id="addSonarrInstance" class="emby-button raised" type="button">+ Add Sonarr instance</button>
+                                <button is="emby-button" type="button" id="validateSonarrMappingsBtn" class="raised emby-button">Validate Mappings</button>
+                            </div>
+                            <div id="sonarrMappingsValidationResult"></div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">movie</i>Radarr</legend>
+                        <div class="configSection">
+                            <div class="je-setting-description" data-desc-for="radarrInstancesList">
+                                <div class="fieldDescription">Movie-focused *arr service. Add one instance per Radarr server.</div>
+                            </div>
                             <div id="radarrInstancesList"></div>
-                            <button id="addRadarrInstance" class="emby-button raised arr-add-btn" type="button">+ Add Radarr Instance</button>
-                            <hr class="je-arr-hr">
-                            <div class="inputContainer je-input-mt je-arr-bazarr-container">
-                                <label class="inputLabel inputLabelUnfocused" for="bazarrUrl">Bazarr URL</label>
+                            <div class="je-arr-action-row">
+                                <button id="addRadarrInstance" class="emby-button raised" type="button">+ Add Radarr instance</button>
+                                <button is="emby-button" type="button" id="validateRadarrMappingsBtn" class="raised emby-button">Validate Mappings</button>
+                            </div>
+                            <div id="radarrMappingsValidationResult"></div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">subtitles</i>Bazarr</legend>
+                        <div class="configSection">
+                            <div class="je-setting-description" data-desc-for="bazarrUrl">
+                                <div class="fieldDescription">Subtitle-management service. Single instance, no API key — detail-page links only.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="bazarrUrl">Bazarr URL</label>
                                 <input id="bazarrUrl" is="emby-input" name="bazarrUrl" type="text" placeholder="e.g., http://192.168.100.100:6767"/>
-                                <div class="fieldDescription">Note: This links to the main movies/series page as Bazarr does not support direct links.</div>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="bazarrUrl">
+                                <div class="fieldDescription">Note: this links to the main movies/series page — Bazarr does not support direct item-deep-links. If Bazarr sits behind an auth proxy (Authentik, Authelia, Cloudflare Access, etc.), put the INTERNAL address here (e.g. <code>http://bazarr:6767</code>) and use the URL Mappings below to redirect user-facing links to the public URL.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="bazarrUrlMappings">Bazarr URL Mappings</label>
+                                <textarea class="emby-textarea emby-input je-textarea-medium" id="bazarrUrlMappings" name="bazarrUrlMappings" placeholder="jellyfin_url|bazarr_url"></textarea>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="bazarrUrlMappings">
+                                <div class="fieldDescription">Map Jellyfin access URLs to Bazarr URLs. Format: <code>jellyfin_url|bazarr_url</code> (one per line).</div>
+                            </div>
+                            <div class="je-arr-action-row">
+                                <button is="emby-button" type="button" id="validateBazarrMappingsBtn" class="raised emby-button">Validate Mappings</button>
+                            </div>
+                            <div id="bazarrMappingsValidationResult"></div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">link</i>*arr UI Links</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="arrLinksEnabled" is="emby-checkbox" type="checkbox"/><span>Enable *arr Links on Detail Pages</span></label></div>
+                            <div class="je-setting-description" data-desc-for="arrLinksEnabled">
+                                <div class="fieldDescription je-field-desc-xl">Show Sonarr, Radarr, and Bazarr links of the items on item detail pages for quick access. Admins only. If no URL is configured for a service above, links for that service are not shown.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="showArrLinksAsText" is="emby-checkbox" type="checkbox"/><span>Show links as text</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showArrLinksAsText">
+                                <div class="fieldDescription">Render the *arr links as plain text labels instead of icon buttons.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="arrLinksShowStatusSingle" is="emby-checkbox" type="checkbox"/><span>Show status badge for single-instance</span></label></div>
+                            <div class="je-setting-description" data-desc-for="arrLinksShowStatusSingle">
+                                <div class="fieldDescription je-field-desc-xl">When off (default), a single matching Sonarr/Radarr instance renders as a plain icon/text. When on, it also shows the episode count (e.g. 22/41) and a colored left border indicating download status. Multi-instance dropdowns always show this detail.</div>
                             </div>
                         </div>
                     </fieldset>
 
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>*arr Links</h3></legend>
+                    <fieldset>
+                        <legend class="sectionTitle"><i class="material-icons je-legend-icon" aria-hidden="true">label</i>Tags Sync</legend>
                         <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="arrLinksEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable *arr Links</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Show Sonarr, Radarr, and Bazarr links of the items on item detail pages for quick access. Only for admins.<br> If no URL is added for a service below, links for that service are not shown.</div>
-                            <div class="je-arr-mappings-section">
-                                <label class="sectionTitle je-seerr-label" for="bazarrUrlMappings">Bazarr URL Mappings</label>
-                                <textarea class="emby-textarea emby-input je-textarea-large" id="bazarrUrlMappings" name="bazarrUrlMappings" placeholder="http://192.168.1.10:8096|http://192.168.1.10:6767&#10;https://jellyfin.example.com|https://bazarr.example.com"></textarea>
-                                <div class="fieldDescription">Map Jellyfin access URLs to Bazarr URLs. Format: <code>jellyfin_url|bazarr_url</code> (one per line).<br>These mappings are useful when accessing Jellyfin via different URLs (e.g., internal network vs. public domain) and you need *arr links to use the appropriate corresponding URL.</div>
-                            </div>
-                            <div class="je-arr-validate-section">
-                                <button is="emby-button" type="button" id="validateArrMappingsBtn" class="raised button-submit emby-button">
-                                    <span>Validate Mappings</span>
-                                </button>
-                                <div id="arrMappingsValidationResult"></div>
-                            </div>
-                            <div class="checkboxContainer je-arr-checkbox-mt">
-                                <label>
-                                    <input id="showArrLinksAsText" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show links as text instead of icons</span>
-                                </label>
-                            </div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="arrLinksShowStatusSingle" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show status badge + color for single-instance links</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When off (default), a single matching Sonarr/Radarr instance renders as a plain icon/text. When on, it also shows the episode count (e.g. 22/41) and a colored left border indicating download status. Multi-instance dropdowns always show this detail.</div>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>*arr Tags Sync</h3></legend>
-                        <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="arrTagsSyncEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable *arr Tags Sync</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">
-                                Fetches all tags from Radarr and Sonarr instances defined above and adds them as Jellyfin tags.
-                                <br><br>
-                                <strong>Note:</strong> Run the sync task from Dashboard > Scheduled Tasks > "Sync Tags from *arr to Jellyfin" and configure how often it should run.
+                            <div class="checkboxContainer"><label><input id="arrTagsSyncEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Tags Sync</span></label></div>
+                            <div class="je-setting-description" data-desc-for="arrTagsSyncEnabled">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    Fetches all tags from Radarr and Sonarr instances defined above and adds them as Jellyfin tags.
+                                    <br/><br/>
+                                <strong>Note:</strong> Run the sync task from Dashboard &gt; Scheduled Tasks &gt; "Sync Tags from *arr to Jellyfin" and configure how often it should run.
+                                </div>
                             </div>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="arrTagsPrefix">Tag Prefix</label>
+                                <label class="inputLabel" for="arrTagsPrefix">Tag Prefix</label>
                                 <input id="arrTagsPrefix" is="emby-input" name="arrTagsPrefix" type="text" placeholder="JE Arr Tag: "/>
-                                <div class="fieldDescription">Prefix to add before each tag (e.g., "JE Arr Tag: " will result in "JE Arr Tag: 1 - Jellyfish")</div>
-                                <br>
-                                <strong>Warning:</strong> Keep the tag prefix constant - it's used to remove old tags before syncing new ones. Having no prefix will remove ALL tags! You can change it, but make sure it's unique.
                             </div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="arrTagsClearOldTags" is="emby-checkbox" type="checkbox"/>
-                                    <span>Clear old tags with prefix before syncing</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, removes all existing tags starting with the prefix before adding new ones. This keeps tags in sync with your *arr applications.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="arrTagsShowAsLinks" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show synced tags as clickable links</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">Displays tags with the configured prefix as clickable links on item detail pages. Helpful if your theme hides tags.</div>
-                            <div class="inputContainer">
-                                <label class="je-label-mb" for="arrTagsSyncFilter">Filter Tags to Sync to Jellyfin (Optional)</label>
-                                <textarea class="emby-textarea emby-input je-textarea-tall" id="arrTagsSyncFilter" name="arrTagsSyncFilter" rows="3" placeholder="1 - Jellyfish&#10;trakt&#10;imdb_250"></textarea>
-                                <br>
-                                <div class="fieldDescription">
-                                    Only sync specific tags from *arr to Jellyfin. Enter one tag name per line (without the prefix).
-                                    <br>Leave empty to sync all tags.
-                                    <br><strong>Example:</strong> If you only want to sync "1 - Jellyfish" and "trakt" tags, enter:
-                                    <br><code>1 - Jellyfish</code>
-                                    <br><code>trakt</code>
+                                <div class="je-setting-description" data-desc-for="arrTagsPrefix">
+                                    <div class="fieldDescription">Prefix to add before each tag (e.g., "JE Arr Tag: " will result in "JE Arr Tag: 1 - Jellyfish")</div>
                                 </div>
+                            <div class="checkboxContainer"><label><input id="arrTagsClearOldTags" is="emby-checkbox" type="checkbox"/><span>Clear old tags before sync</span></label></div>
+                            <div class="je-setting-description" data-desc-for="arrTagsClearOldTags">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, removes all existing tags starting with the prefix before adding new ones. This keeps tags in sync with your *arr applications.</div>
                             </div>
-                            <div class="inputContainer">
-                                <label class="je-label-mb" for="arrTagsLinksFilter">Filter Tags to Show as Links (Optional)</label>
-                                <textarea class="emby-textarea emby-input je-textarea-tall" id="arrTagsLinksFilter" name="arrTagsLinksFilter" rows="3" placeholder="1 - Jellyfish&#10;trakt&#10;imdb_250"></textarea>
-                                <br>
-                                <div class="fieldDescription">
-                                    Only show specific tags as links. Enter one tag name per line (without the prefix).
-                                    <br>Leave empty to show all tags with the prefix.
-                                    <br><strong>Example:</strong> If you only want "JE Arr Tag: 1 - Jellyfish" and "JE Arr Tag: trakt" as links, enter:
-                                    <br><code>1 - Jellyfish</code>
-                                    <br><code>trakt</code>
+                            <div class="checkboxContainer"><label><input id="arrTagsShowAsLinks" is="emby-checkbox" type="checkbox"/><span>Show synced tags as links</span></label></div>
+                            <div class="je-setting-description" data-desc-for="arrTagsShowAsLinks">
+                                <div class="fieldDescription je-field-desc-xl">Displays tags with the configured prefix as clickable links on item detail pages. Helpful if your theme hides tags.</div>
+                            </div>
+
+                            <details class="je-details-section">
+                                <summary>Tag Filters</summary>
+                                <div class="je-details-body">
+                                    <div class="inputContainer">
+                                        <label class="inputLabel">Sync to Jellyfin Filter</label>
+                                        <textarea class="emby-textarea emby-input je-textarea-medium" id="arrTagsSyncFilter" name="arrTagsSyncFilter" placeholder="One per line"></textarea>
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="arrTagsSyncFilter">
+                                            <div class="fieldDescription">
+                                                Only sync specific tags from *arr to Jellyfin. Enter one tag name per line (without the prefix).
+                                                <br/>Leave empty to sync all tags.
+                                                <br/><strong>Example:</strong> If you only want to sync "1 - Jellyfish" and "trakt" tags, enter:
+                                                <br/><code>1 - Jellyfish</code>
+                                            <br/><code>trakt</code>
+                                            </div>
+                                        </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel">Show as Links Filter</label>
+                                        <textarea class="emby-textarea emby-input je-textarea-medium" id="arrTagsLinksFilter" name="arrTagsLinksFilter" placeholder="One per line"></textarea>
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="arrTagsLinksFilter">
+                                            <div class="fieldDescription">
+                                                Only show specific tags as links. Enter one tag name per line (without the prefix).
+                                                <br/>Leave empty to show all tags with the prefix.
+                                                <br/><strong>Example:</strong> If you only want "JE Arr Tag: 1 - Jellyfish" and "JE Arr Tag: trakt" as links, enter:
+                                                <br/><code>1 - Jellyfish</code>
+                                            <br/><code>trakt</code>
+                                            </div>
+                                        </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel">Hide Specific Links Filter</label>
+                                        <textarea class="emby-textarea emby-input je-textarea-medium" id="arrTagsLinksHideFilter" name="arrTagsLinksHideFilter" placeholder="One per line"></textarea>
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="arrTagsLinksHideFilter">
+                                            <div class="fieldDescription">
+                                                Hide specific tags from being displayed as links. Enter one tag name per line (without the prefix).
+                                                <br/>This filter takes priority over the "Show" filter above.
+                                                <br/><strong>Example:</strong> To hide "JE Arr Tag: spam_tag" and "JE Arr Tag: test_tag" from links, enter:
+                                                <br/><code>spam_tag</code>
+                                            <br/><code>test_tag</code>
+                                            </div>
+                                        </div>
                                 </div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="je-label-mb" for="arrTagsLinksHideFilter">Hide Specific Tags from Links (Optional)</label>
-                                <textarea class="emby-textarea emby-input je-textarea-tall" id="arrTagsLinksHideFilter" name="arrTagsLinksHideFilter" rows="3" placeholder="unwanted_tag&#10;spam_tag&#10;test_tag"></textarea>
-                                <br>
-                                <div class="fieldDescription">
-                                    Hide specific tags from being displayed as links. Enter one tag name per line (without the prefix).
-                                    <br>This filter takes priority over the "Show" filter above.
-                                    <br><strong>Example:</strong> To hide "JE Arr Tag: spam_tag" and "JE Arr Tag: test_tag" from links, enter:
-                                    <br><code>spam_tag</code>
-                                    <br><code>test_tag</code>
-                                </div>
-                            </div>
+                            </details>
                         </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Calendar Page</h3></legend>
+                </div>
+
+                <div id="elsewhere" class="jellyfin-tab-content">
+                    <fieldset class="je-fieldset-wide">
+                        <legend class="sectionTitle">Elsewhere (Streaming Providers)</legend>
                         <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="calendarPageEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Calendar Page</span>
-                                </label>
+                            <div class="checkboxContainer"><label><input id="elsewhereEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Elsewhere</span></label></div>
+                            <div class="je-setting-description" data-desc-for="elsewhereEnabled">
+                                <div class="fieldDescription je-field-desc-xl">Adds an "Elsewhere" panel to item detail pages showing where the title is available on streaming services in the user's region (powered by TMDB watch-provider data).</div>
                             </div>
-                            <div class="fieldDescription je-field-desc-xl">Adds a "Calendar" link to the navigation showing upcoming releases from Sonarr/Radarr.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="calendarUsePluginPages" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Plugin Pages for Calendar Page</span>
-                                </label>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="TMDB_API_KEY">TMDB API Key</label>
+                                <div class="je-api-row">
+                                    <input id="TMDB_API_KEY" is="emby-input" name="TMDB_API_KEY" type="password" class="je-api-input"/>
+                                    <span id="tmdbStatusIndicator" class="material-icons"></span>
+                                    <button is="emby-button" type="button" class="testTmdbBtn emby-button raised button-submit">Test</button>
+                                </div>
                             </div>
-                            <div class="fieldDescription je-field-desc-xl">Replaces the default Calendar page with a <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-pages">Plugin Pages</a> implementation.<br><strong>Note:</strong> Jellyfin must be restarted after enabling this option for the first time for changes to take effect.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="calendarUseCustomTabs" is="emby-checkbox" type="checkbox"/>
-                                    <span>Use Custom Tabs for Calendar (instead of sidebar)</span>
-                                </label>
-                            </div>
-                            <div class="je-info-banner-inline">
-                                <div class="je-info-banner-row">
-                                    <i class="material-icons je-info-icon">info</i>
-                                    <div>
-                                        <h4 class="je-custom-tabs-h4">Embed Calendar in Custom Tabs:</h4>
-                                        <p class="fieldDescription je-custom-tabs-p">Display the Calendar page in a Custom Tabs tab instead of the sidebar link.</p>
-                                        <p class="fieldDescription je-custom-tabs-p-mt">You need the <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs">Custom Tabs</a> plugin.</p>
-                                        <ol class="fieldDescription je-custom-tabs-ol">
-                                            <li class="je-custom-tabs-li">Install the <strong>Custom Tabs</strong> plugin and all its prerequisites.</li>
-                                            <li class="je-custom-tabs-li">Navigate to Dashboard > Plugins > Custom Tabs and add a new tab.</li>
-                                            <li class="je-custom-tabs-li">Add "Display Text" according to your preference (e.g., "Calendar").</li>
-                                            <li class="je-custom-tabs-li">Copy the code below and paste it into the 'HTML Content' field.</li>
-                                        </ol>
-                                        <div class="je-copy-code-wrapper">
-                                            <button type="button" class="je-copy-html-btn raised raised-mini emby-button" data-copy-text="&lt;div class=&quot;jellyfinenhanced calendar&quot;&gt;&lt;/div&gt;">
-                                                <i class="material-icons je-copy-icon">content_copy</i>
-                                                <span class="copy-btn-text je-copy-btn-text">Copy</span>
-                                            </button>
-                                            <pre class="je-code-pre"><code>&lt;div class="jellyfinenhanced calendar"&gt;&lt;/div&gt;
-</code></pre>
-                                        </div>
-                                        <div class="fieldDescription je-field-desc-mt">
-                                            Already have Custom Tabs installed?
-                                            <a class="sectionTitle je-custom-tabs-link" href="/web/#/configurationpage?name=Custom%20Tabs">Click here to configure it.</a>
-                                        </div>
+                                    <div class="je-setting-description" data-desc-for="TMDB_API_KEY">
+                                        <div class="fieldDescription">Your API key from The Movie DB (TMDB). <a class="sectionTitle" href="https://www.themoviedb.org/settings/api" target="_blank">How to?</a></div>
+                                        <div class="fieldDescription"><br/>Shared with Seerr Settings</div>
                                     </div>
+
+                            <div style="display:flex; gap:15px; flex-wrap:wrap;">
+                                <div class="inputContainer" style="flex:1;">
+                                    <label class="inputLabel" for="DEFAULT_REGION">Default Region</label>
+                                    <input id="DEFAULT_REGION" is="emby-input" type="text" placeholder="e.g., US"/>
                                 </div>
+                                    <div class="je-setting-description" data-desc-for="DEFAULT_REGION">
+                                        <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt" target="_blank">Full List</a></div>
+                                    </div>
+                                <div class="inputContainer" style="flex:2;">
+                                    <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>
+                                    <input id="DEFAULT_PROVIDERS" class="emby-input" type="text" placeholder="e.g., Netflix,Hulu"/>
+                                </div>
+                                    <div class="je-setting-description" data-desc-for="DEFAULT_PROVIDERS">
+                                        <div class="fieldDescription">A list of default streaming providers to show. Leave blank to show all. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt" target="_blank">Full List</a></div>
+                                    </div>
                             </div>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="calendarFirstDayOfWeek">First Day of Week</label>
-                                <select id="calendarFirstDayOfWeek" is="emby-select">
-                                    <option value="Sunday">Sunday</option>
-                                    <option value="Monday">Monday</option>
-                                    <option value="Tuesday">Tuesday</option>
-                                    <option value="Wednesday">Wednesday</option>
-                                    <option value="Thursday">Thursday</option>
-                                    <option value="Friday">Friday</option>
-                                    <option value="Saturday">Saturday</option>
-                                </select>
+                                <label class="inputLabel" for="IGNORE_PROVIDERS">Ignore Providers</label>
+                                <input id="IGNORE_PROVIDERS" class="emby-input" type="text" placeholder="e.g., .*with Ads, Hulu"/>
                             </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="calendarTimeFormat">Time Format</label>
-                                <select id="calendarTimeFormat" is="emby-select">
-                                    <option value="5pm/5:30pm">5pm/5:30pm</option>
-                                    <option value="17:00/17:30">17:00/17:30</option>
-                                </select>
-                            </div>
-                            <div class="checkboxContainer je-calendar-checkbox-mt">
-                                <label>
-                                    <input id="calendarHighlightFavorites" is="emby-checkbox" type="checkbox"/>
-                                    <span>Highlight Favorites/Watchlist</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">Show a golden border on calendar entries for items in your Jellyfin favorites.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="calendarHighlightWatchedSeries" is="emby-checkbox" type="checkbox"/>
-                                    <span>Highlight Watched Series</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription">Show a border on calendar entries for series you have watched episodes from.</div>
-                            <div class="checkboxContainer je-calendar-checkbox-mt">
-                                <label>
-                                    <input id="calendarFilterByLibraryAccess" is="emby-checkbox" type="checkbox"/>
-                                    <span>Filter by Library Access</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription">When enabled, the calendar only shows items from libraries the user has access to. Upcoming items not yet in Jellyfin are filtered based on their Sonarr/Radarr root folder.</div>
-                            <div class="checkboxContainer je-calendar-checkbox-mt">
-                                <label>
-                                    <input id="calendarShowOnlyRequested" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show Requested Items Only by Default</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription">When enabled, the calendar will load showing only Requested items by default, but users can still change filters.</div>
-                            <div class="checkboxContainer je-calendar-checkbox-mt">
-                                <label>
-                                    <input id="calendarForceOnlyRequested" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show Only Requested Items</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription">When enabled, the calendar always shows only your requested items and the Requests filter is hidden.</div>
+                                <div class="je-setting-description" data-desc-for="IGNORE_PROVIDERS">
+                                    <div class="fieldDescription">A list of providers to ignore from the default region (supports regex).<a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt" target="_blank">Full List</a></div>
+                                </div>
+
+                            <details class="je-details-section">
+                                <summary>Custom Branding</summary>
+                                <div class="je-details-body">
+                                    <div class="inputContainer">
+                                        <label class="inputLabel" for="ElsewhereCustomBrandingText">Custom Branding Msg</label>
+                                        <input id="ElsewhereCustomBrandingText" is="emby-input" type="text" placeholder="e.g., Only available on My Server"/>
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="ElsewhereCustomBrandingText">
+                                            <div class="fieldDescription">Custom message to display when content is not available on any streaming providers. Leave blank to disable custom branding.</div>
+                                        </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel" for="ElsewhereCustomBrandingImageUrl">Custom Branding Icon URL</label>
+                                        <input id="ElsewhereCustomBrandingImageUrl" is="emby-input" type="text" placeholder="/web/assets/img/icon.png"/>
+                                    </div>
+                                        <div class="je-setting-description" data-desc-for="ElsewhereCustomBrandingImageUrl">
+                                            <div class="fieldDescription">Optional URL for an icon to display next to the custom message. Leave blank for no icon.</div>
+                                        </div>
+                                </div>
+                            </details>
                         </div>
-                        <div class="je-info-banner-inline-center">
-                            <div class="je-info-banner-row">
-                                <i class="material-icons je-info-icon">calendar_today</i>
-                                <div>
-                                    <strong>Calendar Page</strong> adds a Calendar Button in sidebar with a dedicated view that displays upcoming releases from Sonarr and Radarr in a calendar view.
-                                    <br><br>
-                                    <strong>Requirements:</strong> Configure Sonarr and/or Radarr URLs and API keys.
-                                </div>
+                    </fieldset>
+
+                    <fieldset class="je-fieldset-wide">
+                        <legend class="sectionTitle">Reviews</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="showReviews" is="emby-checkbox" type="checkbox"/><span>Show TMDB Reviews</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showReviews">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">Requires TMDB API Key to be set</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="reviewsExpandedByDefault" is="emby-checkbox" type="checkbox"/><span>Expand reviews by default</span></label></div>
+                            <div class="je-setting-description" data-desc-for="reviewsExpandedByDefault">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, the reviews section opens expanded by default for all users (unless they override in their session).</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="showUserReviews" is="emby-checkbox" type="checkbox"/><span>Enable User Written Reviews</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showUserReviews">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">Allows users to write reviews and rate items in the library.<br><strong>Completely independent of Elsewhere being enabled and TMDB Reviews being enabled</strong></div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="hideReviewsFromHiddenUsers" is="emby-checkbox" type="checkbox"/><span>Hide reviews from hidden users</span></label></div>
+                            <div class="je-setting-description" data-desc-for="hideReviewsFromHiddenUsers">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, reviews written by Jellyfin users marked as "Hide this user from login screens" are hidden from non-admin viewers. Admins always see all reviews.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="hideReviewsFromDisabledUsers" is="emby-checkbox" type="checkbox"/><span>Hide reviews from disabled users</span></label></div>
+                            <div class="je-setting-description" data-desc-for="hideReviewsFromDisabledUsers">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, reviews written by Jellyfin users marked as "Disable this user" are hidden from non-admin viewers. Admins always see all reviews.</div>
                             </div>
                         </div>
                     </fieldset>
                 </div>
-                 <div id="extras" class="jellyfin-tab-content">
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Other Scripts</h3></legend>
-                        <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="coloredRatingsEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Colored Ratings</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                Applies color-coded backgrounds to media ratings.
-                                <details class="je-screenshot-details">
-                                    <summary class="je-screenshot-summary">View Screenshot</summary>
-                                    <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/ratings.png" target="_blank">
-                                        <img src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/ratings.png" class="je-screenshot-img" alt="Colored Ratings Example">
-                                    </a>
-                                </details>
-                                If you notice missing or incorrect ratings, please submit a PR to <a class="sectionTitle" target="_blank" href="https://github.com/n00bcodr/Jellyfin-Enhanced/">Jellyfin-Enhanced</a>.
-                            </div>
 
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="themeSelectorEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Theme Selector</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                Adds a theme selector to quickly switch between Jellyfish color themes.
-                                <details class="je-screenshot-details">
-                                    <summary class="je-screenshot-summary">View Screenshot</summary>
-                                    <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/theme-selector.png" target="_blank">
-                                        <img src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/theme-selector.png" class="je-screenshot-img" alt="Theme Selector Example">
-                                    </a>
+                <div id="extras" class="jellyfin-tab-content">
+                    <fieldset>
+                        <legend class="sectionTitle">UI Tweaks</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="coloredRatingsEnabled" is="emby-checkbox" type="checkbox"/><span>Colored Ratings Backgrounds</span></label></div>
+                            <div class="je-setting-description" data-desc-for="coloredRatingsEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Applies color-coded backgrounds to media ratings.
+                                    <details class="je-screenshot-details">
+                                <summary class="je-screenshot-summary">View Screenshot</summary>
+                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/ratings.png" target="_blank">
+                                <img alt="Colored Ratings Example" class="je-screenshot-img" src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/ratings.png"/>
+                                </a>
                                 </details>
+                                If you notice missing or incorrect ratings, please submit a PR to <a class="sectionTitle" href="https://github.com/n00bcodr/Jellyfin-Enhanced/" target="_blank">Jellyfin-Enhanced</a>.
                             </div>
-                            <div class="je-note-banner">
+                            </div>
+                            <div class="checkboxContainer"><label><input id="themeSelectorEnabled" is="emby-checkbox" type="checkbox"/><span>Theme Selector (Jellyfish)</span></label></div>
+                            <div class="je-setting-description" data-desc-for="themeSelectorEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Adds a theme selector to quickly switch between Jellyfish color themes.
+                                    <details class="je-screenshot-details">
+                                <summary class="je-screenshot-summary">View Screenshot</summary>
+                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/theme-selector.png" target="_blank">
+                                <img alt="Theme Selector Example" class="je-screenshot-img" src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/theme-selector.png"/>
+                                </a>
+                                </details>
+                                </div>
+                                <div class="je-note-banner">
                                 <i class="material-icons je-note-icon">note</i>
                                 <div>
                                     Only changes the color theme of Jellyfish when used natively, not through KefinTweaks.
                                 </div>
-                            </div>
-
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="coloredActivityIconsEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Colored Activity Icons</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                Replaces Dashboard Activity Icons with Material Design icons and background color.
-                                <details class="je-screenshot-details">
-                                    <summary class="je-screenshot-summary">View Screenshot</summary>
-                                    <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/colored-activity-icons.png" target="_blank">
-                                        <img src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/colored-activity-icons.png" class="je-screenshot-img" alt="Colored Activity Icons Example">
-                                    </a>
-                                </details>
-                            </div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="loginImageEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Login Image</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                Displays the user's profile picture on the manual login screen instead of the name. When a user is selected, their avatar appears above the password field.
-                                <details class="je-screenshot-details">
-                                    <summary class="je-screenshot-summary">View Screenshot</summary>
-                                    <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/login-image.png" target="_blank">
-                                        <img src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/login-image.png" class="je-screenshot-img" alt="Login Image Example">
-                                    </a>
-                                </details>
-                            </div>
-                            <div class="je-danger-banner">
-                                <i class="material-icons je-danger-icon">warning</i>
-                                <div>
-                                    Only use this script if all your users are visible on the login screen. This completely hides the username text input field, making it difficult to manually login.
                                 </div>
                             </div>
-
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="pluginIconsEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Plugin Icons</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                Replaces default plugin folder icons with custom icons on the Dashboard sidebar.
-                                <details class="je-screenshot-details">
-                                    <summary class="je-screenshot-summary">View Screenshot</summary>
-                                    <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/plugin-icons.png" target="_blank">
-                                        <img src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/plugin-icons.png" class="je-screenshot-img-sm" alt="Plugin Icons Example">
-                                    </a>
+                            <div class="checkboxContainer"><label><input id="coloredActivityIconsEnabled" is="emby-checkbox" type="checkbox"/><span>Colored Dashboard Icons</span></label></div>
+                            <div class="je-setting-description" data-desc-for="coloredActivityIconsEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Replaces Dashboard Activity Icons with Material Design icons and background color.
+                                    <details class="je-screenshot-details">
+                                <summary class="je-screenshot-summary">View Screenshot</summary>
+                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/colored-activity-icons.png" target="_blank">
+                                <img alt="Colored Activity Icons Example" class="je-screenshot-img" src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/colored-activity-icons.png"/>
+                                </a>
                                 </details>
+                                </div>
                             </div>
-                            <div class="je-note-banner">
+                            <div class="checkboxContainer"><label><input id="loginImageEnabled" is="emby-checkbox" type="checkbox"/><span>Profile Picture on Login</span></label></div>
+                            <div class="je-setting-description" data-desc-for="loginImageEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Displays the user's profile picture on the manual login screen instead of the name. When a user is selected, their avatar appears above the password field.
+                                    <details class="je-screenshot-details">
+                                <summary class="je-screenshot-summary">View Screenshot</summary>
+                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/login-image.png" target="_blank">
+                                <img alt="Login Image Example" class="je-screenshot-img" src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/login-image.png"/>
+                                </a>
+                                </details>
+                                </div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="pluginIconsEnabled" is="emby-checkbox" type="checkbox"/><span>Custom Plugin Menu Icons</span></label></div>
+                            <div class="je-setting-description" data-desc-for="pluginIconsEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Replaces default plugin folder icons with custom icons on the Dashboard sidebar.
+                                    <details class="je-screenshot-details">
+                                <summary class="je-screenshot-summary">View Screenshot</summary>
+                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/plugin-icons.png" target="_blank">
+                                <img alt="Plugin Icons Example" class="je-screenshot-img-sm" src="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/plugin-icons.png"/>
+                                </a>
+                                </details>
+                                </div>
+                                <div class="je-note-banner">
                                 <i class="material-icons je-note-icon">note</i>
                                 <div>
                                     Currently replaces icons for (if installed): Jellyfin Enhanced, JavaScript Injector, Intro Skipper, Reports, JellySleep, Home Screen Sections, and File Transformation.
                                 </div>
+                                </div>
                             </div>
 
-                            <div class="je-extras-divider">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="activeStreamsEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Active Streams Widget</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                Adds a live stream counter to the header. Click it to open a panel showing who is currently playing, what they're watching, playback state, progress, and transcoding details. By default the widget is only visible to admin accounts.
-                            </div>
-                            <div id="activeStreamsAllUsersContainer">
-                                <div class="checkboxContainer">
-                                    <label>
-                                        <input id="activeStreamsAllUsers" is="emby-checkbox" type="checkbox"/>
-                                        <span>Show to all users</span>
-                                    </label>
-                                </div>
+                            <hr style="border:0; border-top: 1px solid rgba(255,255,255,0.05); margin: 5px 0;">
+
+                            <div class="checkboxContainer"><label><input id="activeStreamsEnabled" is="emby-checkbox" type="checkbox"/><span>Active Streams Header Widget</span></label></div>
+                            <div class="je-setting-description" data-desc-for="activeStreamsEnabled">
                                 <div class="fieldDescription je-field-desc-md">
-                                    Enable this to show it to all users.
+                                    Adds a live stream counter to the header. Click it to open a panel showing who is currently playing, what they're watching, playback state, progress, and transcoding details. By default the widget is only visible to admin accounts.
                                 </div>
                             </div>
+                            <div id="activeStreamsAllUsersContainer" class="checkboxContainer"><label><input id="activeStreamsAllUsers" is="emby-checkbox" type="checkbox"/><span>Show widget to non-admins</span></label></div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend class="sectionTitle">External Links</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="letterboxdEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Letterboxd Links</span></label></div>
+                            <div class="je-setting-description" data-desc-for="letterboxdEnabled">
+                                <div class="fieldDescription je-field-desc-md">Adds Letterboxd links to item details page.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="showLetterboxdLinkAsText" is="emby-checkbox" type="checkbox"/><span>Show link as text</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showLetterboxdLinkAsText">
+                                <div class="fieldDescription je-field-desc-xl">When enabled, shows "Letterboxd" as text instead of the Letterboxd icon.</div>
+                            </div>
+                            <div class="checkboxContainer"><label><input id="metadataIconsEnabled" is="emby-checkbox" type="checkbox"/><span>Enable Metadata Icons (Druidblack)</span></label></div>
+                            <div class="je-setting-description" data-desc-for="metadataIconsEnabled">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Shows metadata icons instead of text. From <a class="sectionTitle" href="https://github.com/Druidblack/jellyfin-icon-metadata" target="_blank">Druidblack/jellyfin-icon-metadata</a>.<br/>
+                                    When enabled, links from the plugin will also use icons instead of text (Letterboxd, *arr Links).
+                                </div>
                             </div>
 
-                            <div class="je-custom-links-section">
-                                <h4 class="sectionTitle je-section-h4">Custom Plugin Links</h4>
-                                <div class="fieldDescription je-field-desc-md">
-                                    Add custom plugin links to the Dashboard sidebar. Each link should be on a new line in the format: <code>Configuration Page Name | icon_name</code>
-                                </div>
-                                <div class="inputContainer je-input-mb">
-                                    <label class="inputLabel inputLabelUnfocused" for="customPluginLinks">Custom Plugin Links</label>
-                                    <textarea id="customPluginLinks" class="emby-textarea emby-input" rows="6" placeholder="Jellyfin Tweaks | auto_awesome&#10;Newsletters | newspaper&#10;Webhook | webhook"></textarea>
+                            <div class="inputContainer" style="margin-top: 10px;">
+                                <label class="inputLabel" for="customPluginLinks">Sidebar Custom Links</label>
+                                <textarea id="customPluginLinks" class="emby-textarea emby-input" rows="3" placeholder="Page Name | icon_name"></textarea>
+                            </div>
+                                <div class="je-setting-description" data-desc-for="customPluginLinks">
                                     <div class="fieldDescription je-field-desc-mt-sm">
-                                        <strong>Format:</strong> <code>Configuration Page Name | Material Icon Name</code><br>
-                                        <strong>Important:</strong> Use the exact name that appears in the configuration page URL (e.g., "Jellyfin%20Tweaks" becomes "Jellyfin Tweaks")<br>
-                                        <br>
-                                        <a href="https://fonts.google.com/icons?icon.set=Material+Icons" target="_blank" class="sectionTitle">Browse Material Icons</a>
+                                    <strong>Format:</strong> <code>Configuration Page Name | Material Icon Name</code><br/>
+                                    <strong>Important:</strong> Use the exact name that appears in the configuration page URL (e.g., "Jellyfin%20Tweaks" becomes "Jellyfin Tweaks")<br/>
+                                    <br/>
+                                    <a class="sectionTitle" href="https://fonts.google.com/icons?icon.set=Material+Icons" target="_blank">Browse Material Icons</a>
+                                    </div>
+                                    <div class="fieldDescription je-field-desc-mt-sm">
+                                        Use "Test Links" to preview your custom plugin links in the sidebar.<br/>Test links will appear immediately and disappear on page refresh.
                                     </div>
                                 </div>
-                                <button id="testCustomPluginLinksBtn" class="raised button-submit emby-button" is="emby-button" type="button">
-                                    <span>Test Links</span>
-                                </button>
-                                <div class="fieldDescription je-field-desc-mt-sm">
-                                    Use "Test Links" to preview your custom plugin links in the sidebar.<br>Test links will appear immediately and disappear on page refresh.
-                                </div>
-                            </div>
+                            <button id="testCustomPluginLinksBtn" class="emby-button raised" type="button" style="width:fit-content;">Test Links</button>
                         </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>External Links</h3></legend>
+
+                    <fieldset class="je-fieldset-wide">
+                        <legend class="sectionTitle">Custom Image Assets</legend>
                         <div class="configSection">
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="letterboxdEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Letterboxd External Links</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">Adds Letterboxd links to item details page.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="showLetterboxdLinkAsText" is="emby-checkbox" type="checkbox"/>
-                                    <span>Show Letterboxd link as text instead of icon</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-xl">When enabled, shows "Letterboxd" as text instead of the Letterboxd icon.</div>
-                            <div class="checkboxContainer">
-                                <label>
-                                    <input id="metadataIconsEnabled" is="emby-checkbox" type="checkbox"/>
-                                    <span>Enable Metadata Icons (by Druidblack)</span>
-                                </label>
-                            </div>
-                            <div class="fieldDescription je-field-desc-md">
-                                Shows metadata icons instead of text. From <a class="sectionTitle" target="_blank" href="https://github.com/Druidblack/jellyfin-icon-metadata">Druidblack/jellyfin-icon-metadata</a>.<br>
-                                When enabled, links from the plugin will also use icons instead of text (Letterboxd, *arr Links.).
-                            </div>
-                        </div>
-                    </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3>Custom Branding</h3></legend>
-                        <div class="configSection">
-                            <div class="je-details-body">
+                            <div class="je-setting-description">
                                 <div class="je-info-banner-compact">
                                     <i class="material-icons je-info-icon-sm">info</i>
                                     <div>
-                                        Requires the <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation">File Transformation Plugin</a> to be installed and enabled. Upload custom PNG images to replace Jellyfin's default web logos.
+                                        Uploading custom icon / favicon / logo images requires the <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank">File Transformation</a> plugin to be installed — it's what replaces Jellyfin's default web logos at request time. Splash screen URL override below works without it.
+                                        <span class="je-installed-badge" data-plugin="filetransformation"><i class="material-icons" aria-hidden="true">check_circle</i>File Transformation detected</span>
                                     </div>
                                 </div>
-                                <div class="je-branding-grid">
-                                    <div class="je-branding-card">
-                                        <label class="je-branding-label-bold">Icon Transparent</label>
-                                        <label class="je-branding-label">The icon in the top-left beside the server version</label>
-                                        <div class="je-branding-meta">
-                                            <strong>Jellyfin Default:</strong> 536x536px (square)<br>
-                                            <strong>Format:</strong> PNG with transparency
-                                        </div>
-                                        <div class="je-branding-dropzone" id="iconTransparentDropZone">
-                                            <input type="file" id="iconTransparentInput" accept="image/*" class="je-branding-file-input" />
-                                            <div id="iconTransparentPlaceholder" class="branding-placeholder je-branding-placeholder">
-                                                <i class="material-icons je-branding-placeholder-icon">image</i>
-                                            </div>
-                                            <img id="iconTransparentPreview" class="je-branding-preview" style="display:none;" />
-                                            <div id="iconTransparentDimensions" class="je-branding-dimensions" style="display:none;"></div>
-                                            <div class="je-branding-hint">Drop image here or click to upload</div>
-                                            <div class="je-branding-maxsize">Max 10MB</div>
-                                            <div id="iconTransparentStatus" class="je-branding-status"></div>
-                                            <button type="button" class="raised button-submit je-branding-delete" id="iconTransparentDelete" title="Delete" style="display:none;" onmouseover="this.style.setProperty('background','#c62828','important')" onmouseout="this.style.setProperty('background','rgba(0,0,0,0.4)','important')">
-                                                <i class="material-icons">delete</i>
-                                            </button>
-                                        </div>
+                            </div>
+
+                            <div class="checkboxContainer"><label><input id="enableCustomSplashScreen" is="emby-checkbox" type="checkbox"/><span>Enable Splash Screen Override</span></label></div>
+                            <div class="je-setting-description" data-desc-for="enableCustomSplashScreen">
+                                <div class="fieldDescription">Replace Jellyfin's login splash background with a custom image URL specified below.</div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="splashScreenImageUrl">Splash Screen Image URL</label>
+                                <input id="splashScreenImageUrl" is="emby-input" type="text" placeholder="/web/assets/banner.png"/>
+                            </div>
+                                <div class="je-setting-description" data-desc-for="splashScreenImageUrl">
+                                    <div class="fieldDescription">URL for the splash screen image. Defaults to Jellyfin banner.</div>
+                                    <div class="je-splash-info-banner">
+                                    <i class="material-icons je-info-icon-sm">info</i>
+                                    <div>
+                                        Might cause strange behaviour if <a class="sectionTitle" href="https://github.com/IAmParadox27/jellyfin-plugin-media-bar" target="_blank">jellyfin-plugin-media-bar</a> is installed.
                                     </div>
-                                    <div class="je-branding-card">
-                                        <label class="je-branding-label-bold">Favicon</label>
-                                        <label class="je-branding-label">Favicon in the browser tab</label>
-                                        <div class="je-branding-meta">
-                                            <strong>Jellyfin Default:</strong> 16x16px, 32x32px, or 48x48px<br>
-                                            <strong>Format:</strong> ICO, PNG, or SVG
-                                        </div>
-                                        <div class="je-branding-dropzone" id="faviconDropZone">
-                                            <input type="file" id="faviconInput" accept="image/*" class="je-branding-file-input" />
-                                            <div id="faviconPlaceholder" class="branding-placeholder je-branding-placeholder">
-                                                <i class="material-icons je-branding-placeholder-icon">image</i>
-                                            </div>
-                                            <img id="faviconPreview" class="je-branding-preview" style="display:none;" />
-                                            <div id="faviconDimensions" class="je-branding-dimensions" style="display:none;"></div>
-                                            <div class="je-branding-hint">Drop image here or click to upload</div>
-                                            <div class="je-branding-maxsize">Max 10MB</div>
-                                            <div id="faviconStatus" class="je-branding-status"></div>
-                                            <button type="button" class="raised button-submit je-branding-delete" id="faviconDelete" title="Delete" style="display:none;" onmouseover="this.style.setProperty('background','#c62828','important')" onmouseout="this.style.setProperty('background','rgba(0,0,0,0.4)','important')">
-                                                <i class="material-icons">delete</i>
-                                            </button>
-                                        </div>
                                     </div>
-                                    <div class="je-branding-card">
-                                        <label class="je-branding-label-bold">Banner Light</label>
-                                        <label class="je-branding-label">Splash Screen Banner for Dark Mode</label>
-                                        <div class="je-branding-meta">
-                                            <strong>Jellyfin Default:</strong> 1302x378px<br>
-                                            <strong>Format:</strong> PNG, JPG, or WebP
-                                        </div>
-                                        <div class="je-branding-dropzone" id="bannerLightDropZone">
-                                            <input type="file" id="bannerLightInput" accept="image/*" class="je-branding-file-input" />
-                                            <div id="bannerLightPlaceholder" class="branding-placeholder je-branding-placeholder">
-                                                <i class="material-icons je-branding-placeholder-icon">image</i>
-                                            </div>
-                                            <img id="bannerLightPreview" class="je-branding-preview" style="display:none;" />
-                                            <div id="bannerLightDimensions" class="je-branding-dimensions" style="display:none;"></div>
-                                            <div class="je-branding-hint">Drop image here or click to upload</div>
-                                            <div class="je-branding-maxsize">Max 10MB</div>
-                                            <div id="bannerLightStatus" class="je-branding-status"></div>
-                                            <button type="button" class="raised button-submit je-branding-delete" id="bannerLightDelete" title="Delete" style="display:none;" onmouseover="this.style.setProperty('background','#c62828','important')" onmouseout="this.style.setProperty('background','rgba(0,0,0,0.4)','important')">
-                                                <i class="material-icons">delete</i>
-                                            </button>
-                                        </div>
+                                    <div class="je-info-banner-inline-center">
+                                    <i class="material-icons je-bottom-info-icon">info</i>
+                                    <div>
+                                        All changes require a page refresh to take effect. <br>
+                                        If old settings persist, please force clear browser cache.
+                                                        </br></div>
                                     </div>
-                                    <div class="je-branding-card">
-                                        <label class="je-branding-label-bold">Banner Dark</label>
-                                        <label class="je-branding-label">Splash Screen Banner for Light Mode</label>
-                                        <div class="je-branding-meta">
-                                            <strong>Jellyfin Default:</strong> 1302x378px<br>
-                                            <strong>Format:</strong> PNG, JPG, or WebP
-                                        </div>
-                                        <div class="je-branding-dropzone" id="bannerDarkDropZone">
-                                            <input type="file" id="bannerDarkInput" accept="image/*" class="je-branding-file-input" />
-                                            <div id="bannerDarkPlaceholder" class="branding-placeholder je-branding-placeholder">
-                                                <i class="material-icons je-branding-placeholder-icon">image</i>
-                                            </div>
-                                            <img id="bannerDarkPreview" class="je-branding-preview" style="display:none;" />
-                                            <div id="bannerDarkDimensions" class="je-branding-dimensions" style="display:none;"></div>
-                                            <div class="je-branding-hint">Drop image here or click to upload</div>
-                                            <div class="je-branding-maxsize">Max 10MB</div>
-                                            <div id="bannerDarkStatus" class="je-branding-status"></div>
-                                            <button type="button" class="raised button-submit je-branding-delete" id="bannerDarkDelete" title="Delete" style="display:none;" onmouseover="this.style.setProperty('background','#c62828','important')" onmouseout="this.style.setProperty('background','rgba(0,0,0,0.4)','important')">
-                                                <i class="material-icons">delete</i>
-                                            </button>
-                                        </div>
+                                </div>
+
+                            <div class="je-branding-grid">
+                                <div class="je-branding-card">
+                                    <label class="je-branding-label-bold">Icon Transparent</label>
+                                    <div class="je-branding-dropzone" id="iconTransparentDropZone">
+                                        <input type="file" id="iconTransparentInput" accept="image/*" class="je-branding-file-input" />
+                                        <div id="iconTransparentPlaceholder" class="je-branding-placeholder"><i class="material-icons je-branding-placeholder-icon">image</i></div>
+                                        <img id="iconTransparentPreview" class="je-branding-preview" style="display:none;" />
+                                        <div id="iconTransparentDimensions" class="je-branding-dimensions" style="display:none;"></div>
+                                        <div id="iconTransparentStatus" class="je-branding-status"></div>
+                                        <button type="button" class="je-branding-delete" id="iconTransparentDelete" style="display:none;"><i class="material-icons">delete</i></button>
                                     </div>
-                                    <div class="je-branding-card">
-                                        <label class="je-branding-label-bold">Apple Touch Icon</label>
-                                        <label class="je-branding-label">Icon shown when adding to iOS Home Screen</label>
-                                        <div class="je-branding-meta">
-                                            <strong>Jellyfin Default:</strong> 180x180px<br>
-                                            <strong>Format:</strong> PNG
-                                        </div>
-                                        <div class="je-branding-dropzone" id="touchiconDropZone">
-                                            <input type="file" id="touchiconInput" accept="image/*" class="je-branding-file-input" />
-                                            <div id="touchiconPlaceholder" class="branding-placeholder je-branding-placeholder">
-                                                <i class="material-icons je-branding-placeholder-icon">image</i>
-                                            </div>
-                                            <img id="touchiconPreview" class="je-branding-preview" style="display:none;" />
-                                            <div id="touchiconDimensions" class="je-branding-dimensions" style="display:none;"></div>
-                                            <div class="je-branding-hint">Drop image here or click to upload</div>
-                                            <div class="je-branding-maxsize">Max 10MB</div>
-                                            <div id="touchiconStatus" class="je-branding-status"></div>
-                                            <button type="button" class="raised button-submit je-branding-delete" id="touchiconDelete" title="Delete" style="display:none;" onmouseover="this.style.setProperty('background','#c62828','important')" onmouseout="this.style.setProperty('background','rgba(0,0,0,0.4)','important')">
-                                                <i class="material-icons">delete</i>
-                                            </button>
-                                        </div>
+                                </div>
+                                <div class="je-branding-card">
+                                    <label class="je-branding-label-bold">Favicon</label>
+                                    <div class="je-branding-dropzone" id="faviconDropZone">
+                                        <input type="file" id="faviconInput" accept="image/*" class="je-branding-file-input" />
+                                        <div id="faviconPlaceholder" class="je-branding-placeholder"><i class="material-icons je-branding-placeholder-icon">image</i></div>
+                                        <img id="faviconPreview" class="je-branding-preview" style="display:none;" />
+                                        <div id="faviconDimensions" class="je-branding-dimensions" style="display:none;"></div>
+                                        <div id="faviconStatus" class="je-branding-status"></div>
+                                        <button type="button" class="je-branding-delete" id="faviconDelete" style="display:none;"><i class="material-icons">delete</i></button>
+                                    </div>
+                                </div>
+                                <div class="je-branding-card">
+                                    <label class="je-branding-label-bold">Banner Dark</label>
+                                    <div class="je-branding-dropzone" id="bannerDarkDropZone">
+                                        <input type="file" id="bannerDarkInput" accept="image/*" class="je-branding-file-input" />
+                                        <div id="bannerDarkPlaceholder" class="je-branding-placeholder"><i class="material-icons je-branding-placeholder-icon">image</i></div>
+                                        <img id="bannerDarkPreview" class="je-branding-preview" style="display:none;" />
+                                        <div id="bannerDarkDimensions" class="je-branding-dimensions" style="display:none;"></div>
+                                        <div id="bannerDarkStatus" class="je-branding-status"></div>
+                                        <button type="button" class="je-branding-delete" id="bannerDarkDelete" style="display:none;"><i class="material-icons">delete</i></button>
+                                    </div>
+                                </div>
+                                <div class="je-branding-card">
+                                    <label class="je-branding-label-bold">Banner Light</label>
+                                    <div class="je-branding-dropzone" id="bannerLightDropZone">
+                                        <input type="file" id="bannerLightInput" accept="image/*" class="je-branding-file-input" />
+                                        <div id="bannerLightPlaceholder" class="je-branding-placeholder"><i class="material-icons je-branding-placeholder-icon">image</i></div>
+                                        <img id="bannerLightPreview" class="je-branding-preview" style="display:none;" />
+                                        <div id="bannerLightDimensions" class="je-branding-dimensions" style="display:none;"></div>
+                                        <div id="bannerLightStatus" class="je-branding-status"></div>
+                                        <button type="button" class="je-branding-delete" id="bannerLightDelete" style="display:none;"><i class="material-icons">delete</i></button>
+                                    </div>
+                                </div>
+                                <div class="je-branding-card">
+                                    <label class="je-branding-label-bold">Apple Touch Icon</label>
+                                    <div class="je-branding-dropzone" id="touchiconDropZone">
+                                        <input type="file" id="touchiconInput" accept="image/*" class="je-branding-file-input" />
+                                        <div id="touchiconPlaceholder" class="je-branding-placeholder"><i class="material-icons je-branding-placeholder-icon">image</i></div>
+                                        <img id="touchiconPreview" class="je-branding-preview" style="display:none;" />
+                                        <div id="touchiconDimensions" class="je-branding-dimensions" style="display:none;"></div>
+                                        <div id="touchiconStatus" class="je-branding-status"></div>
+                                        <button type="button" class="je-branding-delete" id="touchiconDelete" style="display:none;"><i class="material-icons">delete</i></button>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </fieldset>
-                    <fieldset class="verticalSection-extrabottompadding">
-                        <legend class="sectionTitle"><h3></h3></legend>
-                        <div class="configSection">
-                                <div class="je-details-body">
-                                    <div class="checkboxContainer"><label><input id="enableCustomSplashScreen" is="emby-checkbox" type="checkbox"/><span>Enable Custom Splash Screen</span></label></div>
-                                    <div class="inputContainer">
-                                        <label class="inputLabel inputLabelUnfocused" for="splashScreenImageUrl">Splash Screen Image URL</label>
-                                        <input id="splashScreenImageUrl" is="emby-input" name="splashScreenImageUrl" type="text" placeholder="/web/banner-light.b113d4d1c6c07fcb73f0.png"/>
-                                        <div class="fieldDescription">URL for the splash screen image. Defaults to Jellyfin banner.</div>
-                                    </div>
-                                </div>
-                                <div
-                                class="je-splash-info-banner">
-                                <i class="material-icons je-info-icon-sm">info</i>
-                                <div>
-                                    Might cause strange behaviour if <a class="sectionTitle" target="_blank" href="https://github.com/IAmParadox27/jellyfin-plugin-media-bar">jellyfin-plugin-media-bar</a> is installed.
-                                </div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <div
-                    class="je-info-banner-inline-center">
-                    <i class="material-icons je-bottom-info-icon">info</i>
-                    <div>
-                        All changes require a page refresh to take effect. <br/>
-                        If old settings persist, please force clear browser cache.
-                    </div>
-                </div>
-                <div>
-                    <button class="raised button-submit block emby-button" is="emby-button" type="submit">
-                        <span>Save</span>
-                    </button>
                 </div>
 
+                <div id="keyboard" class="jellyfin-tab-content">
+                    <fieldset>
+                        <legend class="sectionTitle">Keyboard Config</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="disableAllShortcuts" is="emby-checkbox" type="checkbox"/><span>Disable Keyboard Shortcuts</span></label></div>
+                            <div class="je-setting-description" data-desc-for="disableAllShortcuts">
+                                <div class="fieldDescription">Disables all keyboard shortcuts, and hides the 'Shortcuts' tab in enhanced panel</div>
+                                <div class="je-info-banner">
+                                <div class="je-info-banner-row">
+                                <i class="material-icons je-info-icon">info</i>
+                                <div>
+                                <strong>This will save the current configuration and apply all the above settings to every user on this server.</strong><br/>
+                                <strong>Note:</strong> Users can individually customize their own settings by opening the Enhanced Panel:<br/>
+                                • Press <code>?</code> key (default shortcut)<br/>
+                                • Long Press on user profile picture in the top-right corner<br/>
+                                • Through "Jellyfin Enhanced" link from the side bar<br/>
+                                • Access via playback controls menu during video playback (only on mobile devices)
+                            </div>
+                                </div>
+                                </div>
+                            </div>
+                            <hr style="border:0; border-top: 1px solid rgba(255,255,255,0.05); margin: 5px 0;">
+
+                            <h4>Add Override</h4>
+                            <div style="display:flex; gap:10px; align-items:center;">
+                                <select is="emby-select" class="emby-select" id="add-shortcut-select" style="flex:1;"></select>
+                                <input is="emby-input" id="add-shortcut-key" type="text" placeholder="Key (e.g. Shift+A)" style="flex:1;"/>
+                                <div class="je-setting-description" data-desc-for="add-shortcut-key">
+                                    <p class="fieldDescription je-field-desc-mt">
+                                    <b>Modifier Keys:</b> Use `Shift+`, `Ctrl+`, or `Alt+`. Examples: `Shift+A`, `Ctrl+S`.
+                                    </p>
+                                </div>
+                                <button is="emby-button" type="button" id="add-shortcut-btn" class="emby-button raised">Add</button>
+                            </div>
+                            <div id="shortcut-error-comment" style="display: none; color: #ff6b6b; margin-top:5px;"></div>
+
+                            <h4 style="margin-top:20px;">Current Overrides</h4>
+                            <div id="shortcut-list-container" style="display:flex; flex-direction:column; gap:10px;"></div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div id="docs" class="jellyfin-tab-content">
+                    <div class="je-docs-header">
+                        <span class="je-docs-title">
+                            <i class="material-icons je-legend-icon" aria-hidden="true">menu_book</i>
+                            Documentation
+                        </span>
+                        <a target="_blank" rel="noopener" href="https://n00bcodr.github.io/Jellyfin-Enhanced/" class="je-docs-open-link" aria-label="Open documentation in new tab">
+                            <i class="material-icons" aria-hidden="true">open_in_new</i>
+                            Open in new tab
+                        </a>
+                    </div>
+                    <iframe id="docsFrame"
+                            class="je-docs-iframe"
+                            title="Jellyfin Enhanced Documentation"
+                            src="about:blank"
+                            loading="lazy"
+                            referrerpolicy="no-referrer"
+                            sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"></iframe>
+                </div>
+
+                <div class="je-apply-hint">
+                    Settings require a page refresh to take effect. Clear browser cache if changes persist.
+                </div>
+
+                <div class="je-save-dock" role="toolbar" aria-label="Save settings">
+                    <button class="emby-button raised button-submit je-save-dock-btn" type="submit">
+                        <i class="material-icons je-save-dock-icon" aria-hidden="true">save</i>
+                        <span>Save Settings</span>
+                    </button>
+                </div>
             </form>
         </div>
     </div>
@@ -1753,6 +1820,47 @@
 
             const page = document.querySelector('#JellyfinEnhancedPage');
             const form = document.querySelector('#JellyfinEnhancedForm');
+
+            // Theme detector: Jellyfin's themes hard-swap theme.css (no CSS
+            // variable contract) so we infer dark vs. light from the computed
+            // background-color of <html>. Dark themes return something like
+            // rgb(16,16,16) (sum ~48); the Light theme returns rgb(242,242,242)
+            // (sum 726). Threshold at 450 bins every shipped theme correctly.
+            // We also re-run on `load` in case the theme sheet hadn't applied
+            // by the time our initial check ran, and once more after ~600 ms
+            // to catch late Jellyfin theme swaps during dashboard navigation.
+            function _jeDetectTheme() {
+                if (!page) return;
+                // Wrap the read in try/catch — during SPA detach getComputedStyle
+                // can throw InvalidAccessError. If anything goes wrong we fall
+                // back to dark (matches the plugin's previous default) so the
+                // rest of the IIFE's listener wiring isn't aborted by a throw
+                // from this purely cosmetic detector.
+                try {
+                    var bg = getComputedStyle(document.documentElement).backgroundColor;
+                    var m = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+                    if (!m) {
+                        // Named colors (`black`), `transparent`, or `initial`: can't
+                        // tell light vs. dark reliably. Log once so a future broken
+                        // theme is diagnosable rather than silently dark.
+                        console.warn('[JE] theme detector: document background is unparseable (' + bg + '); defaulting to dark');
+                        page.classList.remove('je-light-theme');
+                        page.classList.add('je-dark-theme');
+                        return;
+                    }
+                    var sum = (+m[1]) + (+m[2]) + (+m[3]);
+                    var isLight = sum > 450;
+                    page.classList.toggle('je-light-theme', isLight);
+                    page.classList.toggle('je-dark-theme',  !isLight);
+                } catch (e) {
+                    console.warn('[JE] theme detection failed, defaulting to dark:', e);
+                    page.classList.remove('je-light-theme');
+                    page.classList.add('je-dark-theme');
+                }
+            }
+            _jeDetectTheme();
+            window.addEventListener('load', _jeDetectTheme);
+            setTimeout(_jeDetectTheme, 600);
             const resetAllUserSettingsBtn = document.querySelector('#resetAllUserSettingsBtn');
             const clearTagsCacheBtn = document.querySelector('#clearTagsCacheBtn');
 
@@ -1772,7 +1880,91 @@
             const tabs = document.querySelectorAll('.jellyfin-tab-button');
             const tabContents = document.querySelectorAll('.jellyfin-tab-content');
 
+            // Drag-to-scroll on the tab bar so mouse users can pan the tab strip
+            // the same way touch users do on mobile (the overflow-x auto strip
+            // has no visible scrollbar). Threshold at 5 px before we consider it
+            // a drag, so a normal click through to a tab still registers.
+            (function wireTabBarDrag() {
+                const bar = document.querySelector('.je-tab-bar');
+                if (!bar) return;
+                let isDown = false;
+                let startX = 0;
+                let startScroll = 0;
+                let dragged = false;
+
+                bar.addEventListener('mousedown', (e) => {
+                    if (e.button !== 0) return;
+                    isDown = true;
+                    dragged = false;
+                    startX = e.pageX;
+                    startScroll = bar.scrollLeft;
+                });
+                bar.addEventListener('mousemove', (e) => {
+                    if (!isDown) return;
+                    const dx = e.pageX - startX;
+                    if (!dragged && Math.abs(dx) > 5) {
+                        dragged = true;
+                        bar.classList.add('je-dragging');
+                    }
+                    if (dragged) {
+                        bar.scrollLeft = startScroll - dx;
+                        e.preventDefault();
+                    }
+                });
+                const end = () => {
+                    if (!isDown) return;
+                    isDown = false;
+                    // Keep `dragged` set briefly so the synthesized click that
+                    // follows a drag-end can be suppressed by the capture-phase
+                    // click listener below. Cleared on next mousedown.
+                    bar.classList.remove('je-dragging');
+                };
+                bar.addEventListener('mouseup', end);
+                bar.addEventListener('mouseleave', end);
+
+                // Capture-phase click listener cancels the click that mouseup
+                // would otherwise fire on the tab button at the cursor's final
+                // position — prevents accidental tab activation at drag-end.
+                bar.addEventListener('click', (e) => {
+                    if (dragged) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        dragged = false;
+                    }
+                }, true);
+            })();
+
+            // Docs iframe URL — kept in JS rather than hardcoded in the
+            // <iframe src> attribute so we can lazy-load on first Docs
+            // activation (saves the GitHub Pages fetch for admins who
+            // never open this tab).
+            const DOCS_URL = 'https://n00bcodr.github.io/Jellyfin-Enhanced/';
+
+            // Per-tab scroll memory. When the admin switches tabs we save the
+            // current scrollY under the outgoing tab's id, and when they come
+            // back to a tab we restore whatever they were reading. Defaults to
+            // scroll-to-top on first visit to a tab so the Overview / long
+            // sections always start at the tab's own header.
+            const _jeTabScroll = Object.create(null);
+            let _jePrevTabId = null;
+            function _jeGetScrollTop() {
+                return window.scrollY
+                    || document.documentElement.scrollTop
+                    || document.body.scrollTop
+                    || 0;
+            }
+            function _jeSetScrollTop(y) {
+                try { window.scrollTo({ top: y, behavior: 'instant' }); }
+                catch (e) {
+                    // Old Safari missing behavior:'instant' or iframe contexts.
+                    window.scrollTo(0, y);
+                }
+            }
+
             function activateTab(tabId) {
+                if (_jePrevTabId && _jePrevTabId !== tabId) {
+                    _jeTabScroll[_jePrevTabId] = _jeGetScrollTop();
+                }
                 tabs.forEach(t => {
                     const isActive = t.dataset.tab === tabId;
                     if (isActive) {
@@ -1790,6 +1982,58 @@
                     const isActive = content.id === tabId;
                     content.classList.toggle('active', isActive);
                 });
+                // Restore (or reset) the scroll position after the new tab's
+                // content is in the DOM. rAF waits for the layout pass so the
+                // saved scrollY actually addresses the right document height.
+                const saved = _jeTabScroll[tabId];
+                requestAnimationFrame(() => _jeSetScrollTop(saved || 0));
+                _jePrevTabId = tabId;
+                // Lazy-load the Docs iframe the first time the user opens
+                // the Docs tab. Using `about:blank` as the initial src
+                // prevents the GitHub Pages fetch for admins who never
+                // click into it. We set the real src once and never
+                // reset it, so subsequent tab switches re-reveal the
+                // already-loaded page (keeps the admin's scroll position
+                // and any in-page nav state).
+                if (tabId === 'docs') {
+                    try {
+                        var f = document.getElementById('docsFrame');
+                        if (f && (!f.src || f.src === 'about:blank' || /about:blank/.test(f.src))) {
+                            // Set up a load-timeout fallback before assigning src so
+                            // a silently-blank iframe (DNS/CSP/X-Frame-Options/CDN
+                            // outage) becomes a visible "couldn't load — open in
+                            // new tab" message instead of an empty gray box.
+                            var loaded = false;
+                            f.addEventListener('load', function onLoad() {
+                                loaded = true;
+                                f.removeEventListener('load', onLoad);
+                            });
+                            setTimeout(function() {
+                                if (loaded) return;
+                                var parent = f.parentNode;
+                                if (!parent) return;
+                                var fb = document.createElement('div');
+                                fb.className = 'je-docs-fallback';
+                                fb.style.cssText = 'padding: 24px; text-align: center; color: #ccc; font-size: 0.95em;';
+                                var msg = document.createElement('div');
+                                msg.textContent = "Couldn't load the embedded documentation. Open it in a new tab instead:";
+                                msg.style.marginBottom = '12px';
+                                var link = document.createElement('a');
+                                link.href = DOCS_URL;
+                                link.target = '_blank';
+                                link.rel = 'noopener';
+                                link.textContent = DOCS_URL;
+                                link.style.color = 'var(--primary-accent-color, #00a4dc)';
+                                fb.appendChild(msg);
+                                fb.appendChild(link);
+                                parent.replaceChild(fb, f);
+                            }, 8000);
+                            f.src = DOCS_URL;
+                        }
+                    } catch (e) {
+                        console.warn('[JE] docs iframe lazy-load failed:', e);
+                    }
+                }
             }
 
             tabs.forEach(tab => {
@@ -1805,14 +2049,67 @@
                 });
             });
 
+            // Map legacy tab IDs (pre-redesign) to the closest new tab, so users with
+            // a saved sessionStorage value from the old layout don't land on a missing tab.
+            const LEGACY_TAB_MAP = {
+                'enhanced': 'display',
+                'jellyseerr': 'seerr',
+                'arr-links': 'arr'
+            };
+
             // Restore tab from sessionStorage on page load
             try {
-                const savedTab = sessionStorage.getItem('jellyfinEnhancedActiveTab');
+                let savedTab = sessionStorage.getItem('jellyfinEnhancedActiveTab');
+                if (savedTab && LEGACY_TAB_MAP[savedTab]) {
+                    savedTab = LEGACY_TAB_MAP[savedTab];
+                    sessionStorage.setItem('jellyfinEnhancedActiveTab', savedTab);
+                }
                 if (savedTab && document.getElementById(savedTab)) {
                     activateTab(savedTab);
+                } else if (savedTab) {
+                    // Saved tab doesn't match any current tab and isn't a legacy key —
+                    // probably a tab that was later renamed or a stray value. Clear it
+                    // so the user stops silently getting ignored on every page load.
+                    console.info('[JE] discarding unknown saved tab: ' + savedTab);
+                    sessionStorage.removeItem('jellyfinEnhancedActiveTab');
                 }
             } catch (e) {
-                // Ignore if sessionStorage is not available
+                // sessionStorage unavailable (private mode / quota / security) — skip restore.
+            }
+
+            // === Setting-description visibility toggle ===
+            // Some admins want the full explanatory text under every setting;
+            // others (who know the plugin) want a compact page. Persist the
+            // preference in localStorage, default visible, expose a header
+            // button to flip state. Visibility is driven by CSS on the body
+            // class — toggling is instant and costs nothing per render.
+            const descToggleBtn = document.getElementById('toggleDescriptionsBtn');
+            const DESC_PREF_KEY = 'je-settings-descriptions-visible';
+            function applyDescriptionVisibility(show) {
+                try { document.body.classList.toggle('je-hide-descriptions', !show); } catch (e) {}
+                if (descToggleBtn) {
+                    descToggleBtn.setAttribute('aria-pressed', show ? 'true' : 'false');
+                    descToggleBtn.classList.toggle('je-desc-toggle-off', !show);
+                    const label = descToggleBtn.querySelector('.je-desc-toggle-label');
+                    if (label) label.textContent = show ? 'Descriptions' : 'Descriptions off';
+                }
+            }
+            (function initDescriptionVisibility() {
+                let show = true;
+                try {
+                    const stored = localStorage.getItem(DESC_PREF_KEY);
+                    if (stored === 'false') show = false;
+                } catch (e) { /* private mode / quota — default visible */ }
+                applyDescriptionVisibility(show);
+            })();
+            if (descToggleBtn) {
+                descToggleBtn.addEventListener('click', function() {
+                    const currentlyShown = !document.body.classList.contains('je-hide-descriptions');
+                    const nextShown = !currentlyShown;
+                    applyDescriptionVisibility(nextShown);
+                    try { localStorage.setItem(DESC_PREF_KEY, nextShown ? 'true' : 'false'); }
+                    catch (e) { /* private mode / quota — preference won't persist, UI still toggles */ }
+                });
             }
 
             // === Settings Search ===
@@ -1835,6 +2132,7 @@
 
             searchInput.addEventListener('keydown', (e) => {
                 if (e.key === 'Escape') {
+                    clearTimeout(searchDebounce);  // kill the debounce so a stale non-empty query can't re-enter search mode after we exit
                     searchInput.value = '';
                     performSearch('');
                     searchInput.blur();
@@ -1847,6 +2145,7 @@
             });
 
             searchClear.addEventListener('click', () => {
+                clearTimeout(searchDebounce);  // kill the debounce — see Escape handler
                 searchInput.value = '';
                 performSearch('');
                 searchInput.focus();
@@ -1977,14 +2276,23 @@
                 clearHighlights();
                 form.querySelectorAll('.je-search-tab-label').forEach(el => el.remove());
                 if (tabButtonsContainer) tabButtonsContainer.style.display = '';
+                // Clear inline display from every tab content. performSearch sets
+                // `style.display = 'block'|'none'` per tab; without this reset the
+                // inline value wins over `.jellyfin-tab-content.active { display: grid }`,
+                // collapsing matched tabs to single-column or hiding tabs that had no
+                // match the next time the user clicks them. The .active class alone
+                // owns visibility outside of search mode.
+                form.querySelectorAll('.jellyfin-tab-content').forEach(tc => { tc.style.display = ''; });
                 form.querySelectorAll('.je-search-hidden').forEach(el => el.classList.remove('je-search-hidden'));
                 form.querySelectorAll('details').forEach(d => {
                     if (savedDetailsStates.has(d)) d.open = savedDetailsStates.get(d);
                 });
                 savedDetailsStates.clear();
-                let savedTab = 'enhanced';
+                let savedTab = 'overview';
                 try {
-                    savedTab = sessionStorage.getItem('jellyfinEnhancedActiveTab') || 'enhanced';
+                    savedTab = sessionStorage.getItem('jellyfinEnhancedActiveTab') || 'overview';
+                    if (LEGACY_TAB_MAP[savedTab]) savedTab = LEGACY_TAB_MAP[savedTab];
+                    if (!document.getElementById(savedTab)) savedTab = 'overview';
                 } catch (e) {
                     // Ignore if sessionStorage is not available
                 }
@@ -2207,10 +2515,11 @@
                 return;
             }
 
+            const _testToken = (typeof beginConnectionTest === 'function') ? beginConnectionTest() : undefined;
             testJellyseerrBtn.disabled = true;
             jellyseerrStatusIndicator.textContent = 'sync';
             jellyseerrStatusIndicator.className = 'material-icons status-check';
-            jellyseerrStatusIndicator.style.color = '#00a4dc';
+            jellyseerrStatusIndicator.style.color = 'var(--primary-accent-color, #00a4dc)';
 
             let validated = false;
             let lastError = '';
@@ -2238,11 +2547,13 @@
             if (validated) {
                 jellyseerrStatusIndicator.textContent = 'check_circle';
                 jellyseerrStatusIndicator.style.color = '#52b54b';
-                Dashboard.alert({ title: 'Success', message: 'Successfully connected to Seerr!' });
+                try { setConnectionTestResult('seerr', 'ok', 'Connected', _testToken); } catch (e) { /* cache is best-effort */ }
+                jeTestAlert({ title: 'Success', message: 'Successfully connected to Seerr!' });
             } else {
                 jellyseerrStatusIndicator.textContent = 'error';
                 jellyseerrStatusIndicator.style.color = '#dc3545';
-                Dashboard.alert({ title: 'Connection Failed', message: lastError || 'Could not connect to any provided URL.' });
+                try { setConnectionTestResult('seerr', 'error', (lastError && lastError.length < 80) ? lastError : 'Connection failed', _testToken); } catch (e) { /* cache is best-effort */ }
+                jeTestAlert({ title: 'Connection Failed', message: lastError || 'Could not connect to any provided URL.' });
             }
         }
 
@@ -2254,6 +2565,8 @@
                 return;
             }
 
+            const _testToken = (typeof beginConnectionTest === 'function') ? beginConnectionTest() : undefined;
+
             // Determine which status indicator to update based on button context
             const button = event.target.closest('button');
             const statusIndicator = button.parentElement.querySelector('.material-icons') || tmdbStatusIndicator;
@@ -2264,7 +2577,7 @@
 
             statusIndicator.textContent = 'sync';
             statusIndicator.className = 'material-icons status-check';
-            statusIndicator.style.color = '#00a4dc';
+            statusIndicator.style.color = 'var(--primary-accent-color, #00a4dc)';
 
             try {
                 const validationUrl = ApiClient.getUrl(`/JellyfinEnhanced/tmdb/validate`, { apiKey: apiKey });
@@ -2272,7 +2585,8 @@
 
                 statusIndicator.textContent = 'check_circle';
                 statusIndicator.style.color = '#52b54b';
-                Dashboard.alert({ title: 'Success', message: 'Successfully connected to TMDB!' });
+                try { setConnectionTestResult('tmdb', 'ok', 'API key valid', _testToken); } catch (err) { /* cache is best-effort */ }
+                jeTestAlert({ title: 'Success', message: 'Successfully connected to TMDB!' });
 
             } catch (e) {
                 console.error('TMDB validation failed:', e);
@@ -2287,7 +2601,13 @@
 
                 statusIndicator.textContent = 'error';
                 statusIndicator.style.color = '#dc3545';
-                Dashboard.alert({ title: 'Connection Failed', message: errorMessage });
+                try {
+                    var shortDetail = e.status === 401 ? 'API key rejected'
+                        : (e.status === 500 || e.status === 0 || !e.status) ? 'Unreachable'
+                        : 'Error ' + e.status;
+                    setConnectionTestResult('tmdb', 'error', shortDetail, _testToken);
+                } catch (err) { /* cache is best-effort */ }
+                jeTestAlert({ title: 'Connection Failed', message: errorMessage });
             } finally {
                 allTestButtons.forEach(btn => btn.disabled = false);
                 if (statusIndicator) {
@@ -2299,9 +2619,26 @@
 
         /** @type {boolean} Tracks whether the File Transformation warning has been dismissed this session */
         var ftWarningDismissedSession = false;
+        // Plugin detection state.
+        //
+        // Each `hasX` is tri-state: `null` (not yet probed or probe failed),
+        // `true` (installed AND Status === "Active"), `false` (not installed
+        // OR installed but disabled). When the plugin is installed-but-
+        // disabled, we additionally record it in `_jeDisabledPlugins` so the
+        // Optional Dependencies card can surface "Installed (disabled)"
+        // instead of the blunt "Not installed".
         var hasPluginPages = null;
         var hasCustomTabs = null;
         var hasIntroSkipper = null;
+        var hasFileTransformation = null;
+        var hasKefinTweaks = null;
+        var _jeDisabledPlugins = {}; // key -> true when installed but Status !== 'Active'
+        // Tri-state compat probe result for Custom Tabs:
+        //   null           — not yet probed (or Custom Tabs not installed)
+        //   'ok'           — /Plugins/.../Configuration returned the expected shape
+        //   'incompatible' — config read but shape doesn't match { Tabs:[{Title,ContentHtml}] }
+        //   'probe-failed' — HTTP/JSON/auth error reading the config
+        var customTabsCompatState = null;
 
         /**
          * Checks installed plugins (File Transformation, Plugin Pages, Custom Tabs).
@@ -2315,10 +2652,87 @@
                 url: ApiClient.getUrl('/Plugins'),
                 dataType: 'json'
             }).then(function(plugins) {
-                var hasFileTransformation = plugins.some(function(p) { return p.Name === 'File Transformation'; });
-                hasPluginPages = plugins.some(function(p) { return p.Name === 'Plugin Pages'; });
-                hasCustomTabs = plugins.some(function(p) { return p.Name === 'Custom Tabs'; });
-                hasIntroSkipper = plugins.some(function(p) { return p.Name === 'Intro Skipper' || p.Name === 'SkipIntro'; });
+                setProbeWarning('plugins', null);
+                // Status-aware plugin lookup. Returns tri-state:
+                //   true  → installed AND active
+                //   false → either not installed OR disabled
+                // When disabled, also records it in _jeDisabledPlugins[key] so
+                // the Optional Dependencies card can show "Installed (disabled)".
+                _jeDisabledPlugins = {};
+                function probe(key, names) {
+                    var match = null;
+                    var lowered = names.map(function(n) { return n.toLowerCase(); });
+                    for (var i = 0; i < plugins.length; i++) {
+                        var nm = (plugins[i].Name || '').toLowerCase();
+                        if (lowered.indexOf(nm) !== -1) { match = plugins[i]; break; }
+                    }
+                    if (!match) return false;
+                    // Jellyfin returns Status as one of: Active, Disabled, Restart,
+                    // NotSupported, Malfunctioned, Superseded. Anything else → log
+                    // once and treat as disabled so the dashboard surfaces a warning
+                    // rather than silently passing through. Old builds that omit
+                    // Status entirely are caught here too — better to see "Installed
+                    // but status unknown" than misreport as Active.
+                    //
+                    // Rendering note: `_jeDisabledPlugins[key]` captures the raw
+                    // Status string. The Optional Dependencies dashboard renders
+                    // "Installed but disabled in Dashboard > Plugins" for any
+                    // non-Active value. That copy is accurate for Disabled but
+                    // slightly misleading for Restart ("waiting for server restart")
+                    // and Superseded ("replaced by newer version, probably still
+                    // usable"). Callers wanting distinct copy per status should
+                    // branch on the raw value.
+                    var status = match.Status;
+                    var active = status === 'Active';
+                    if (!active) {
+                        _jeDisabledPlugins[key] = status || 'Status unknown';
+                        if (status && ['Disabled', 'Restart', 'NotSupported', 'Malfunctioned', 'Superseded'].indexOf(status) === -1) {
+                            console.warn('[JE] plugin ' + match.Name + ' has unexpected Status value: ' + JSON.stringify(status));
+                        }
+                    }
+                    return active;
+                }
+                hasFileTransformation = probe('fileTransformation', ['File Transformation']);
+                hasPluginPages        = probe('pluginPages',        ['Plugin Pages']);
+                hasCustomTabs         = probe('customTabs',         ['Custom Tabs']);
+                hasIntroSkipper       = probe('introSkipper',       ['Intro Skipper', 'SkipIntro']);
+
+                // KefinTweaks installs as a web-mod (files in /config/KefinTweaks/
+                // injected via File Transformation into index.html), NOT as a
+                // .NET plugin — so it never appears in /Plugins. Detect it at
+                // runtime instead: the injector sets `window.KefinTweaksConfig`
+                // and adds script tags whose src contains "KefinTweaks".
+                try {
+                    hasKefinTweaks = !!(window.KefinTweaksConfig ||
+                        document.querySelector('script[src*="KefinTweaks"]'));
+                } catch (e) {
+                    // Extremely unlikely (the selector is literal and the window
+                    // read is same-origin), but a future isolation/CSP quirk could
+                    // throw — log so we can distinguish "detection bug" from
+                    // "legitimately not installed" in bug reports.
+                    console.warn('[JE] KefinTweaks detection threw; treating as absent:', e);
+                    hasKefinTweaks = false;
+                }
+
+                // Toggle body classes so descriptions hide install-only content
+                // (e.g., "Install the Custom Tabs plugin...") and surface a positive
+                // "detected" badge when an integration plugin is already present.
+                document.body.classList.toggle('je-has-customtabs',        hasCustomTabs         === true);
+                document.body.classList.toggle('je-has-pluginpages',       hasPluginPages        === true);
+                document.body.classList.toggle('je-has-introskipper',      hasIntroSkipper       === true);
+                document.body.classList.toggle('je-has-kefintweaks',       hasKefinTweaks        === true);
+                document.body.classList.toggle('je-has-filetransformation', hasFileTransformation === true);
+
+                // If Custom Tabs is present, probe its config to decide whether the
+                // schema matches what we know how to write. Only on success do we
+                // reveal the "Add the Custom Tabs entry for me" toggles.
+                if (hasCustomTabs === true) {
+                    customTabsCompatState = null; // re-probing
+                    checkCustomTabsConfigCompat();
+                } else {
+                    document.body.classList.remove('je-has-customtabs-compat');
+                    customTabsCompatState = null;
+                }
 
                 // File Transformation warning
                 if (!ftWarningDismissedSession && localStorage.getItem('je_ft_warning_dismissed') !== 'true') {
@@ -2330,8 +2744,32 @@
 
                 // Re-run dependencies now that plugin info is available
                 updateAllDependencies();
-            }).catch(function() {
-                // If we can't check, don't show the warning
+            }).catch(function(err) {
+                // Plugin list request failed (network, auth expiry, server offline, ...).
+                // Leave hasPluginPages/hasIntroSkipper at null so individual deps show
+                // "unknown" rather than incorrectly disabling toggles. Still refresh
+                // the dashboard so cards don't sit stuck on "Checking..." forever.
+                console.warn('[JE] plugin detection failed; resetting detection state to avoid stale UI:', err);
+                // Reset detection state so prior-success flags don't contradict
+                // the visible "couldn't reach /Plugins" warning. Body classes,
+                // module flags, and dep gates all flip back to "unknown" so the
+                // UI is internally consistent after a failed retry.
+                hasPluginPages = null;
+                hasCustomTabs = null;
+                hasIntroSkipper = null;
+                hasFileTransformation = null;
+                hasKefinTweaks = null;
+                customTabsCompatState = null;
+                document.body.classList.remove('je-has-customtabs', 'je-has-pluginpages', 'je-has-introskipper', 'je-has-customtabs-compat', 'je-has-kefintweaks', 'je-has-filetransformation');
+                setProbeWarning('plugins', "Couldn't reach the Jellyfin /Plugins endpoint to verify which integrations are installed (auth expiry, network, or server issue). Dependency hints and \"plugin detected\" badges are now hidden until you retry.");
+                try { updateAllDependencies(); } catch (e) {
+                    console.warn('[JE] updateAllDependencies threw during plugin-detect fallback:', e);
+                }
+                try {
+                    updateStatusDashboard();
+                } catch (e) {
+                    console.warn('[JE] updateStatusDashboard threw during plugin-detect fallback:', e);
+                }
             });
 
             // Set up dismiss button handlers
@@ -2349,6 +2787,236 @@
                     document.getElementById('fileTransformationWarning').style.display = 'none';
                 };
             }
+            // Probe-warning retry — re-runs plugin detection (which also re-runs
+            // the Custom Tabs config probe inside its .then). One handler only;
+            // checkInstalledPlugins is idempotent.
+            var probeRetry = document.getElementById('je-probe-retry-btn');
+            if (probeRetry && !probeRetry.dataset.jeWired) {
+                probeRetry.dataset.jeWired = '1';
+                probeRetry.onclick = function() {
+                    setProbeWarning('plugins', null);
+                    setProbeWarning('customtabs', null);
+                    checkInstalledPlugins();
+                };
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Custom Tabs auto-management
+        //
+        // The Custom Tabs plugin (https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs)
+        // stores its tab list at /Plugins/{guid}/Configuration as
+        // `{ "Tabs": [{ "Title": "...", "ContentHtml": "..." }, ...] }`.
+        // We can manage individual entries on the user's behalf, but only when
+        // the schema we observe matches that shape exactly. If the schema has
+        // changed in a future release, every code path here bails out silently
+        // and the related UI ("Add the Custom Tabs entry for me" toggles) stays
+        // hidden — the user falls back to manual setup with no error noise.
+        // ---------------------------------------------------------------------
+        var CUSTOM_TABS_PLUGIN_ID = 'fbacd0b6fd464a05b0a42045d6a135b0';
+
+        // Per managed Custom Tabs entry: which JE config flags drive it
+        // (parent + auto-create), what Title to write, and the exact
+        // ContentHtml snippet that JE's matching front-end module looks for.
+        // ContentHtml strings are the SOURCE OF TRUTH for "this tab is ours" —
+        // the sync logic identifies our entries by exact-string match.
+        // `masterKey` is the top-level feature toggle (Enable Bookmarks / Enable
+        // Hidden Content / Enable Requests Page / Enable Calendar Page). Sync
+        // requires ALL THREE — masterKey, parentKey, autoKey — to be true for
+        // the entry to exist. Without masterKey in the predicate, disabling the
+        // master feature would leave an orphan Custom Tabs entry that opens to
+        // broken/empty content (the JE module behind it is off).
+        var CUSTOM_TAB_MANAGED_ENTRIES = [
+            { masterKey: 'BookmarksEnabled',      parentKey: 'BookmarksUseCustomTabs',     autoKey: 'BookmarksAutoCreateCustomTab',     ownedKey: 'BookmarksCustomTabJeOwned',     title: 'Bookmarks',      html: '<div class="sections bookmarks"></div>' },
+            { masterKey: 'HiddenContentEnabled',  parentKey: 'HiddenContentUseCustomTabs', autoKey: 'HiddenContentAutoCreateCustomTab', ownedKey: 'HiddenContentCustomTabJeOwned', title: 'Hidden Content', html: '<div class="jellyfinenhanced hidden-content"></div>' },
+            { masterKey: 'DownloadsPageEnabled',  parentKey: 'DownloadsUseCustomTabs',     autoKey: 'DownloadsAutoCreateCustomTab',     ownedKey: 'DownloadsCustomTabJeOwned',     title: 'Requests',       html: '<div class="jellyfinenhanced requests"></div>' },
+            { masterKey: 'CalendarPageEnabled',   parentKey: 'CalendarUseCustomTabs',      autoKey: 'CalendarAutoCreateCustomTab',      ownedKey: 'CalendarCustomTabJeOwned',      title: 'Calendar',       html: '<div class="jellyfinenhanced calendar"></div>' }
+        ];
+
+        function isCustomTabsConfigShapeOk(cfg) {
+            if (!cfg || typeof cfg !== 'object') return false;
+            if (!Array.isArray(cfg.Tabs)) return false;
+            for (var i = 0; i < cfg.Tabs.length; i++) {
+                var t = cfg.Tabs[i];
+                if (!t || typeof t !== 'object') return false;
+                if (typeof t.Title !== 'string' || typeof t.ContentHtml !== 'string') return false;
+            }
+            return true;
+        }
+
+        // Surfaces a single probe-failure banner above the form. Multiple probes
+        // (plugin list, Custom Tabs config schema) can fail independently — the
+        // banner aggregates them so the admin sees one actionable message instead
+        // of nothing. Pass an empty/null msg to clear the banner for that source.
+        var _jeProbeWarnings = Object.create(null);
+        function setProbeWarning(source, msg) {
+            if (msg) _jeProbeWarnings[source] = msg;
+            else delete _jeProbeWarnings[source];
+            var banner = document.getElementById('je-probe-warning');
+            var msgEl = document.getElementById('je-probe-warning-msg');
+            if (!banner || !msgEl) return;
+            var keys = Object.keys(_jeProbeWarnings);
+            if (keys.length === 0) {
+                banner.style.display = 'none';
+                msgEl.textContent = '';
+            } else {
+                msgEl.textContent = ' — ' + keys.map(function(k) { return _jeProbeWarnings[k]; }).join(' / ');
+                banner.style.display = '';
+            }
+        }
+
+        function checkCustomTabsConfigCompat() {
+            ApiClient.ajax({
+                type: 'GET',
+                url: ApiClient.getUrl('/Plugins/' + CUSTOM_TABS_PLUGIN_ID + '/Configuration'),
+                dataType: 'json'
+            }).then(function(cfg) {
+                var ok = isCustomTabsConfigShapeOk(cfg);
+                document.body.classList.toggle('je-has-customtabs-compat', ok);
+                customTabsCompatState = ok ? 'ok' : 'incompatible';
+                if (!ok) {
+                    console.warn('[JE] Custom Tabs config schema not recognized; auto-manage toggles hidden.');
+                    setProbeWarning('customtabs', "Custom Tabs config has an unrecognized shape. Auto-create toggles disabled until Jellyfin Enhanced supports the new schema.");
+                } else {
+                    setProbeWarning('customtabs', null);
+                }
+                try { renderOptionalPluginsDashboard(); } catch (e) {
+                    console.warn('[JE] renderOptionalPluginsDashboard threw from checkCustomTabsConfigCompat (then):', e);
+                }
+            }).catch(function(err) {
+                document.body.classList.remove('je-has-customtabs-compat');
+                customTabsCompatState = 'probe-failed';
+                console.warn('[JE] Custom Tabs config probe failed; auto-manage toggles hidden:', err);
+                setProbeWarning('customtabs', "Couldn't read Custom Tabs config (check Jellyfin logs). Auto-create toggles disabled until the probe succeeds.");
+                try { renderOptionalPluginsDashboard(); } catch (e) {
+                    console.warn('[JE] renderOptionalPluginsDashboard threw from checkCustomTabsConfigCompat (catch):', e);
+                }
+            });
+        }
+
+        /**
+         * Plan + apply Custom Tabs sync for every managed entry.
+         *
+         * Returns a promise resolving to `{ ok, status, detail, ownedUpdates }`:
+         *  - `ok: true` → sync ran cleanly (or was a clean no-op)
+         *  - `ok: false` → something failed; `detail` describes it (admin-visible)
+         *  - `status: 'noop' | 'ok' | 'skipped' | 'failed'`
+         *  - `ownedUpdates: [{ ownedKey, value }]` — *JE-side* flag updates the caller
+         *    must persist alongside the rest of the JE config so future syncs know
+         *    which entries we created vs. which the admin added manually.
+         *
+         * Sync rules per managed entry (uses `ownedKey` to gate destructive deletes):
+         *  - shouldExist (auto+parent both on) AND no matching CT entry → ADD; owned=true
+         *  - shouldExist AND a matching CT entry exists → leave entry alone; preserve owned
+         *  - !shouldExist AND a matching CT entry exists AND we own it → REMOVE; owned=false
+         *  - !shouldExist AND a matching CT entry exists but we don't own it → leave it
+         *    (it's the admin's manually-created tab); owned stays false
+         *  - !shouldExist AND no matching entry → no-op; owned=false
+         *
+         * The single GET → mutate → single POST sequence avoids the race where
+         * multiple per-entry round-trips would clobber each other.
+         */
+        function syncAllManagedCustomTabs(savedConfig) {
+            if (!document.body.classList.contains('je-has-customtabs-compat')) {
+                // Bail early. If the admin has auto-create intent stored but we
+                // can't act on it (plugin missing / compat probe failed), return
+                // ok:false so the save-flow alert gate fires — otherwise the
+                // green "Saved!" toast masks the dropped intent.
+                // Mirror `shouldExist`: intent requires all three flags —
+                // master + parent + auto. A disabled-at-master feature with
+                // auto+parent still checked wouldn't have a real sync action
+                // anyway, so shouldn't trigger the cosmetic "saved but CT
+                // dropped your auto-create" alert.
+                var anyIntent = CUSTOM_TAB_MANAGED_ENTRIES.some(function(e) {
+                    return savedConfig[e.autoKey] === true
+                        && savedConfig[e.parentKey] === true
+                        && savedConfig[e.masterKey] === true;
+                });
+                return Promise.resolve({
+                    ok: !anyIntent, // only "skipped cleanly" when there was nothing to do
+                    status: 'skipped',
+                    detail: anyIntent
+                        ? 'Custom Tabs is not detected (or its config schema is unrecognized). Auto-create was requested but skipped — toggle a Custom Tabs setting to retry the probe.'
+                        : 'Custom Tabs not detected; nothing to sync.',
+                    ownedUpdates: []
+                });
+            }
+            return ApiClient.ajax({
+                type: 'GET',
+                url: ApiClient.getUrl('/Plugins/' + CUSTOM_TABS_PLUGIN_ID + '/Configuration'),
+                dataType: 'json'
+            }).then(function(cfg) {
+                if (!isCustomTabsConfigShapeOk(cfg)) {
+                    return {
+                        ok: false,
+                        status: 'failed',
+                        detail: 'Custom Tabs configuration shape no longer matches what Jellyfin Enhanced knows how to write — auto-manage skipped to avoid corrupting it.',
+                        ownedUpdates: []
+                    };
+                }
+                var changed = false;
+                var ownedUpdates = [];
+                CUSTOM_TAB_MANAGED_ENTRIES.forEach(function(entry) {
+                    // ALL three gates must be on: the master feature, the
+                    // Use-Custom-Tabs child toggle, and the Auto-Create
+                    // opt-in. Missing the master-flag check here meant
+                    // disabling the top-level feature still left an orphan
+                    // CT entry that opened to broken content.
+                    var shouldExist =
+                        savedConfig[entry.autoKey] === true &&
+                        savedConfig[entry.parentKey] === true &&
+                        savedConfig[entry.masterKey] === true;
+                    var isOwned = savedConfig[entry.ownedKey] === true;
+                    var idx = -1;
+                    for (var i = 0; i < cfg.Tabs.length; i++) {
+                        if (cfg.Tabs[i].ContentHtml === entry.html) { idx = i; break; }
+                    }
+                    if (shouldExist && idx === -1) {
+                        cfg.Tabs.push({ Title: entry.title, ContentHtml: entry.html });
+                        changed = true;
+                        ownedUpdates.push({ ownedKey: entry.ownedKey, value: true });
+                    } else if (shouldExist /* && idx !== -1 */) {
+                        // Entry already exists — preserve current owned flag. Do NOT
+                        // claim ownership of an existing entry that we didn't add,
+                        // so that the admin can manage it manually if they later
+                        // turn auto-create off.
+                        ownedUpdates.push({ ownedKey: entry.ownedKey, value: isOwned });
+                    } else if (!shouldExist && idx !== -1 && isOwned) {
+                        // We created this; safe to remove.
+                        cfg.Tabs.splice(idx, 1);
+                        changed = true;
+                        ownedUpdates.push({ ownedKey: entry.ownedKey, value: false });
+                    } else {
+                        // !shouldExist + (no entry, OR entry but not ours) → leave alone.
+                        ownedUpdates.push({ ownedKey: entry.ownedKey, value: false });
+                    }
+                });
+                if (!changed) {
+                    return { ok: true, status: 'noop', detail: 'Custom Tabs already in sync.', ownedUpdates: ownedUpdates };
+                }
+                return ApiClient.ajax({
+                    type: 'POST',
+                    url: ApiClient.getUrl('/Plugins/' + CUSTOM_TABS_PLUGIN_ID + '/Configuration'),
+                    contentType: 'application/json',
+                    data: JSON.stringify(cfg)
+                }).then(function() {
+                    return { ok: true, status: 'ok', detail: 'Custom Tabs updated.', ownedUpdates: ownedUpdates };
+                }).catch(function(err) {
+                    return {
+                        ok: false,
+                        status: 'failed',
+                        detail: 'Custom Tabs update failed: ' + ((err && err.message) || 'see console'),
+                        ownedUpdates: []  // do NOT persist owned flags if the POST didn't land
+                    };
+                });
+            }).catch(function(err) {
+                return {
+                    ok: false,
+                    status: 'failed',
+                    detail: 'Could not read Custom Tabs configuration: ' + ((err && err.message) || 'see console'),
+                    ownedUpdates: []
+                };
+            });
         }
 
         // Auto Movie Request - Quality Profile Mode helpers
@@ -2493,9 +3161,15 @@
             // Enabled toggle lives in the summary row so admins can flip it without expanding
             // the card. stopPropagation on pointer events prevents the <details> from toggling
             // open/closed when the user clicks the checkbox itself.
+            // Styled via .arr-instance-enabled CSS (see configPage.css). We intentionally
+            // do NOT use is="emby-checkbox" — that custom element expects a <label> wrapper
+            // with a sibling <span>, which we can't provide inside a <details><summary> row
+            // without breaking the flex layout of the name/URL/disabled chip.
+            var ariaName = (instance.Name || '').trim() || defaultName;
             var enabledCheckbox = createEl('input', {
                 type: 'checkbox',
                 className: 'arr-instance-enabled',
+                'aria-label': 'Enable ' + ariaName + ' instance',
                 title: 'Uncheck to skip this instance in all fan-out paths (links, calendar, queue, tag sync) without deleting its URL/API key'
             });
             if (initiallyEnabled) enabledCheckbox.checked = true;
@@ -2526,7 +3200,9 @@
 
             var urlLabel = createEl('label', { className: 'inputLabel inputLabelUnfocused', textContent: 'URL' });
             var urlInput = createEl('input', { className: 'arr-instance-url emby-input', type: 'text', placeholder: urlPlaceholder, value: instance.Url || '' });
-            var urlContainer = createEl('div', { className: 'inputContainer', style: 'margin-top: 0.5em;' }, [urlLabel, urlInput]);
+            var defaultPort = type === 'sonarr' ? '8989' : '7878';
+            var urlDesc = createEl('div', { className: 'fieldDescription', textContent: 'The Jellyfin server uses this URL to talk to ' + (type === 'sonarr' ? 'Sonarr' : 'Radarr') + ' directly. If your public URL sits behind an auth proxy (Authentik, Authelia, Cloudflare Access, etc.), put the INTERNAL address here (e.g. http://' + type + ':' + defaultPort + ' or http://192.168.x.y:' + defaultPort + ') and use the URL Mappings below to redirect user-facing links to the public URL.' });
+            var urlContainer = createEl('div', { className: 'inputContainer', style: 'margin-top: 0.5em;' }, [urlLabel, urlInput, urlDesc]);
 
             var apiLabel = createEl('label', { className: 'inputLabel inputLabelUnfocused', textContent: 'API Key' });
             var apiInput = createEl('input', { className: 'arr-instance-apikey emby-input', type: 'password', placeholder: 'API key (find in Settings > General > Security)', value: instance.ApiKey || '' });
@@ -2537,13 +3213,16 @@
             var apiDesc = createEl('div', { className: 'fieldDescription', textContent: 'Find this in ' + (type === 'sonarr' ? 'Sonarr' : 'Radarr') + ' under Settings > General > Security > API Key' });
             var apiContainer = createEl('div', { className: 'inputContainer', style: 'margin-top: 0.5em;' }, [apiLabel, apiRow, apiDesc]);
 
-            var mappingsTextarea = createEl('textarea', { className: 'arr-instance-urlmappings emby-textarea emby-input', style: 'display:block; height: 8vh !important; margin-top: 0.5em;', placeholder: 'jellyfin_url|arr_url (one per line)' });
+            // URL Mappings shown inline (no nested <details>) — the whole card already
+            // expands behind its own <details>, so doubling up on collapses hides a
+            // frequently-edited field one extra click deep.
+            var mappingsLabel = createEl('label', { className: 'inputLabel inputLabelUnfocused', textContent: 'URL Mappings (optional)' });
+            var mappingsTextarea = createEl('textarea', { className: 'arr-instance-urlmappings emby-textarea emby-input', style: 'display:block; height: 8vh !important; margin-top: 0.25em;', placeholder: 'jellyfin_url|arr_url (one per line)' });
             mappingsTextarea.value = instance.UrlMappings || '';
-            var mappingsDesc = createEl('div', { className: 'fieldDescription', textContent: 'Map Jellyfin access URLs to this instance\'s URL. Format: jellyfin_url|arr_url (one per line). Useful for reverse proxy setups.' });
-            var mappingsSummary = createEl('summary', { style: 'cursor:pointer; color: rgba(255,255,255,0.6); font-size: 0.9em;', textContent: 'URL Mappings (optional)' });
-            var mappingsDetails = createEl('details', { style: 'margin-top: 0.5em;' }, [mappingsSummary, mappingsTextarea, mappingsDesc]);
+            var mappingsDesc = createEl('div', { className: 'fieldDescription', textContent: 'Map Jellyfin access URLs to this instance\'s URL. Format: jellyfin_url|arr_url (one per line). Useful for reverse-proxy setups.' });
+            var mappingsContainer = createEl('div', { className: 'inputContainer', style: 'margin-top: 0.5em;' }, [mappingsLabel, mappingsTextarea, mappingsDesc]);
 
-            var body = createEl('div', { className: 'arr-instance-card-body' }, [header, urlContainer, apiContainer, mappingsDetails]);
+            var body = createEl('div', { className: 'arr-instance-card-body' }, [header, urlContainer, apiContainer, mappingsContainer]);
 
             // The card is a <details> element
             var card = document.createElement('details');
@@ -2556,7 +3235,9 @@
 
             // Keep summary text in sync with name/url inputs
             nameInput.addEventListener('input', function() {
-                summaryNameSpan.textContent = nameInput.value.trim() || defaultName;
+                var n = nameInput.value.trim() || defaultName;
+                summaryNameSpan.textContent = n;
+                enabledCheckbox.setAttribute('aria-label', 'Enable ' + n + ' instance');
             });
             urlInput.addEventListener('input', function() {
                 summaryUrlSpan.textContent = urlInput.value.trim();
@@ -2564,10 +3245,15 @@
 
             // Toggle visual dim state + summary "(disabled)" chip when the Enabled checkbox
             // changes. The backend is the authority — this is UI feedback only until Save.
+            // Also re-renders the Overview Service Status card so a disabled instance
+            // instantly shows as "Disabled" instead of a stale red/green badge.
             enabledCheckbox.addEventListener('change', function() {
                 var en = enabledCheckbox.checked;
                 summaryDisabledSpan.style.display = en ? 'none' : 'inline';
                 card.classList.toggle('arr-instance-disabled', !en);
+                try { renderServiceStatusDashboard(); } catch (e) {
+                    console.warn('[JE] renderServiceStatusDashboard threw from arr-instance enable-toggle:', e);
+                }
             });
 
             // Confirm before removing
@@ -2683,6 +3369,63 @@
             });
         }
 
+        // Requests Page requirements line — hides once Sonarr, Radarr AND
+        // Seerr all have URL + API key configured, shows with a dynamic list
+        // of what's still missing otherwise. The surrounding info banner
+        // itself stays visible; only the "Requirements:" sentence toggles.
+        // Runs off the live DOM so typing a URL/API key updates immediately
+        // without needing a save-and-reload.
+        function updateRequestsRequirementsBanner() {
+            var line = document.getElementById('requestsPageRequirementsLine');
+            if (!line) return;
+            var list = document.getElementById('requestsPageRequirementsList');
+
+            function hasCompleteInstance(listId) {
+                var root = document.getElementById(listId);
+                if (!root) return false;
+                // Walk each instance card (the <details class="arr-instance-card"> element
+                // built by createInstanceCard). Matching on the real card wrapper avoids
+                // closest() landing on the inner .inputContainer div, which only contains
+                // the URL input and misses the API-key sibling.
+                var cards = root.querySelectorAll('.arr-instance-card');
+                for (var i = 0; i < cards.length; i++) {
+                    var urlEl = cards[i].querySelector('.arr-instance-url');
+                    var apiEl = cards[i].querySelector('.arr-instance-apikey');
+                    var url = urlEl ? (urlEl.value || '').trim() : '';
+                    var api = apiEl ? (apiEl.value || '').trim() : '';
+                    if (url && api) return true;
+                }
+                return false;
+            }
+
+            var sonarrOK = hasCompleteInstance('sonarrInstancesList');
+            var radarrOK = hasCompleteInstance('radarrInstancesList');
+            var seerrUrlsEl = document.getElementById('jellyseerrUrls');
+            var seerrKeyEl = document.getElementById('JellyseerrApiKey');
+            var seerrOK = seerrUrlsEl && (seerrUrlsEl.value || '').trim().length > 0 &&
+                          seerrKeyEl && (seerrKeyEl.value || '').trim().length > 0;
+
+            if (sonarrOK && radarrOK && seerrOK) {
+                line.style.display = 'none';
+                return;
+            }
+
+            var missing = [];
+            if (!sonarrOK) missing.push('Sonarr');
+            if (!radarrOK) missing.push('Radarr');
+            if (!seerrOK) missing.push('Seerr');
+            var missingText;
+            if (missing.length === 1) {
+                missingText = missing[0] + ' (URL and API key)';
+            } else if (missing.length === 2) {
+                missingText = missing.join(' and ') + ' (URL and API key each)';
+            } else {
+                missingText = missing.slice(0, -1).join(', ') + ', and ' + missing[missing.length - 1] + ' (URL and API key each)';
+            }
+            if (list) list.textContent = 'Still to configure: ' + missingText + '.';
+            line.style.display = '';
+        }
+
         function collectInstancesFromDom(selector, defaultName) {
             var out = [];
             var incomplete = [];
@@ -2769,10 +3512,20 @@
 
         // ==================== End Multi-Instance Arr Management ====================
 
+        // Cache of the four "JE owns this Custom Tabs entry" booleans from the
+        // most recently loaded config. Sync uses these to decide whether a
+        // matching CT entry was created by JE (safe to delete) or by the admin
+        // (must not touch). saveConfig writes the updated values back as part
+        // of its single config write.
+        var _jeCustomTabOwnedCache = Object.create(null);
+
         function loadConfig() {
             Dashboard.showLoadingMsg();
             checkInstalledPlugins();
             ApiClient.getPluginConfiguration(pluginId).then((config) => {
+                CUSTOM_TAB_MANAGED_ENTRIES.forEach(function(entry) {
+                    _jeCustomTabOwnedCache[entry.ownedKey] = config[entry.ownedKey] === true;
+                });
                 const savedShortcuts = (config.Shortcuts && config.Shortcuts.length > 0) ? config.Shortcuts : defaultShortcuts;
                 shortcutOverrides = savedShortcuts.filter(saved => {
                     const def = defaultShortcuts.find(d => d.Name === saved.Name);
@@ -2914,6 +3667,8 @@
                 document.querySelector('#bookmarksEnabled').checked = config.BookmarksEnabled !== false;
                 document.querySelector('#bookmarksUsePluginPages').checked = config.BookmarksUsePluginPages === true;
                 document.querySelector('#bookmarksUseCustomTabs').checked = config.BookmarksUseCustomTabs === true;
+                var __bAuto = document.querySelector('#bookmarksAutoCreateCustomTab');
+                if (__bAuto) __bAuto.checked = config.BookmarksAutoCreateCustomTab === true;
                 document.querySelector('#useIcons').checked = config.UseIcons !== false;
                 document.querySelector('#iconStyle').value = config.IconStyle || 'emoji';
                 document.querySelector('#arrLinksEnabled').checked = config.ArrLinksEnabled;
@@ -2968,12 +3723,16 @@
                 document.querySelector('#downloadsPageShowIssues').checked = config.DownloadsPageShowIssues === true;
                 document.querySelector('#downloadsUsePluginPages').checked = config.DownloadsUsePluginPages !== false;
                 document.querySelector('#downloadsUseCustomTabs').checked = config.DownloadsUseCustomTabs === true;
+                var __dAuto = document.querySelector('#downloadsAutoCreateCustomTab');
+                if (__dAuto) __dAuto.checked = config.DownloadsAutoCreateCustomTab === true;
                 document.querySelector('#downloadsPagePollingEnabled').checked = config.DownloadsPagePollingEnabled !== false;
                 document.querySelector('#downloadsPollIntervalSeconds').value = (config.DownloadsPollIntervalSeconds !== undefined && config.DownloadsPollIntervalSeconds !== null) ? config.DownloadsPollIntervalSeconds : 30;
 
                 // Calendar Page settings
                 document.querySelector('#calendarPageEnabled').checked = config.CalendarPageEnabled !== false;
                 document.querySelector('#calendarUseCustomTabs').checked = config.CalendarUseCustomTabs === true;
+                var __cAuto = document.querySelector('#calendarAutoCreateCustomTab');
+                if (__cAuto) __cAuto.checked = config.CalendarAutoCreateCustomTab === true;
                 document.querySelector('#calendarUsePluginPages').checked = config.CalendarUsePluginPages !== false;
                 document.querySelector('#calendarFirstDayOfWeek').value = config.CalendarFirstDayOfWeek || 'Monday';
                 document.querySelector('#calendarTimeFormat').value = config.CalendarTimeFormat || '5pm/5:30pm';
@@ -2987,6 +3746,8 @@
                 document.querySelector('#hiddenContentEnabled').checked = config.HiddenContentEnabled || false;
                 document.querySelector('#hiddenContentUsePluginPages').checked = config.HiddenContentUsePluginPages === true;
                 document.querySelector('#hiddenContentUseCustomTabs').checked = config.HiddenContentUseCustomTabs === true;
+                var __hAuto = document.querySelector('#hiddenContentAutoCreateCustomTab');
+                if (__hAuto) __hAuto.checked = config.HiddenContentAutoCreateCustomTab === true;
 
                 document.querySelector('#loginImageEnabled').checked = config.EnableLoginImage || false;
                 document.querySelector('#customPluginLinks').value = config.CustomPluginLinks || '';
@@ -3008,6 +3769,10 @@
 
                 // Update TMDB-dependent settings after config is loaded
                 updateAllDependencies();
+
+                // Refresh the Requests Page requirements banner off freshly-
+                // rendered instance cards and loaded Seerr fields.
+                updateRequestsRequirementsBanner();
 
                 Dashboard.hideLoadingMsg();
             });
@@ -3136,6 +3901,8 @@
             config.BookmarksEnabled = document.querySelector('#bookmarksEnabled').checked;
             config.BookmarksUsePluginPages = document.querySelector('#bookmarksUsePluginPages').checked;
             config.BookmarksUseCustomTabs = document.querySelector('#bookmarksUseCustomTabs').checked;
+            var __bAutoSave = document.querySelector('#bookmarksAutoCreateCustomTab');
+            config.BookmarksAutoCreateCustomTab = !!(__bAutoSave && __bAutoSave.checked);
             config.UseIcons = document.querySelector('#useIcons').checked;
             config.IconStyle = document.querySelector('#iconStyle').value;
 
@@ -3192,10 +3959,14 @@
             const pollInterval = parseInt(document.querySelector('#downloadsPollIntervalSeconds').value, 10);
             config.DownloadsPollIntervalSeconds = pollInterval >= 30 ? pollInterval : 30;
             config.DownloadsUseCustomTabs = document.querySelector('#downloadsUseCustomTabs').checked;
+            var __dAutoSave = document.querySelector('#downloadsAutoCreateCustomTab');
+            config.DownloadsAutoCreateCustomTab = !!(__dAutoSave && __dAutoSave.checked);
 
             // Calendar Page settings
             config.CalendarPageEnabled = document.querySelector('#calendarPageEnabled').checked;
             config.CalendarUseCustomTabs = document.querySelector('#calendarUseCustomTabs').checked;
+            var __cAutoSave = document.querySelector('#calendarAutoCreateCustomTab');
+            config.CalendarAutoCreateCustomTab = !!(__cAutoSave && __cAutoSave.checked);
             config.CalendarUsePluginPages = document.querySelector('#calendarUsePluginPages').checked;
             config.CalendarFirstDayOfWeek = document.querySelector('#calendarFirstDayOfWeek').value || 'Monday';
             config.CalendarTimeFormat = document.querySelector('#calendarTimeFormat').value || '5pm/5:30pm';
@@ -3209,35 +3980,163 @@
             config.HiddenContentEnabled = document.querySelector('#hiddenContentEnabled').checked;
             config.HiddenContentUsePluginPages = document.querySelector('#hiddenContentUsePluginPages').checked;
             config.HiddenContentUseCustomTabs = document.querySelector('#hiddenContentUseCustomTabs').checked;
+            var __hAutoSave = document.querySelector('#hiddenContentAutoCreateCustomTab');
+            config.HiddenContentAutoCreateCustomTab = !!(__hAutoSave && __hAutoSave.checked);
 
             config.EnableLoginImage = document.querySelector('#loginImageEnabled').checked;
             config.CustomPluginLinks = document.querySelector('#customPluginLinks').value || '';
 
+            // Carry the cached "JE owns this Custom Tabs entry" flags through any
+            // round-trip; sync may overwrite specific keys after computing actions.
+            CUSTOM_TAB_MANAGED_ENTRIES.forEach(function(entry) {
+                config[entry.ownedKey] = _jeCustomTabOwnedCache[entry.ownedKey] === true;
+            });
+
             return config;
         }
 
+        /**
+         * Run sync, then if any owned-flag updates were produced, persist them
+         * back to JE config in a second write so future saves see the new state.
+         * Returns the (possibly downgraded) sync result so the caller can surface
+         * any failure to the admin.
+         *
+         * Cache discipline: `_jeCustomTabOwnedCache` is mutated ONLY after the
+         * server confirms the owned-flag write. On failure we re-read the live
+         * config and restore the cache to ground truth — otherwise a partial
+         * write would leave the in-memory cache disagreeing with what the next
+         * page-load will see, causing JE to silently orphan its own tabs on
+         * future cleanup. The downgraded result tells `saveConfig` to surface
+         * the partial-success to the admin.
+         */
+        async function runCustomTabsSync(config) {
+            const syncResult = await syncAllManagedCustomTabs(config);
+            if (!syncResult || !Array.isArray(syncResult.ownedUpdates) || syncResult.ownedUpdates.length === 0) {
+                return syncResult;
+            }
+            // Detect changes against the cache, but DO NOT mutate the cache yet.
+            const pendingUpdates = syncResult.ownedUpdates.filter(function(u) {
+                return _jeCustomTabOwnedCache[u.ownedKey] !== u.value;
+            });
+            if (pendingUpdates.length === 0) {
+                return syncResult;
+            }
+            // Narrow second-write: fetch the latest config from the server first,
+            // then apply ONLY the owned-flag delta. This minimizes the race window
+            // where an interleaving save (double-click, "Apply to all users", or
+            // a concurrent admin in another browser tab) would otherwise be lost
+            // if we replayed the form's stale snapshot on top. Any unrelated
+            // fields the other save wrote are preserved because we only mutate
+            // the `*CustomTabJeOwned` keys on the fresh copy.
+            let fresh;
+            try {
+                fresh = await ApiClient.getPluginConfiguration(pluginId);
+            } catch (fetchErr) {
+                console.error('[JE] Could not re-fetch config for owned-flag persist:', fetchErr);
+                fresh = null;
+            }
+            const target = fresh || config; // fall back to form state if fetch fails
+            pendingUpdates.forEach(function(u) { target[u.ownedKey] = u.value; });
+            try {
+                await ApiClient.updatePluginConfiguration(pluginId, target);
+                // Server confirmed — commit cache.
+                pendingUpdates.forEach(function(u) {
+                    _jeCustomTabOwnedCache[u.ownedKey] = u.value;
+                });
+                return syncResult;
+            } catch (persistErr) {
+                console.error('[JE] Failed to persist Custom Tabs owned-flag updates:', persistErr);
+                // Roll cache back to ground truth so the next save's plan
+                // computes against the actual server state, not a poisoned cache.
+                try {
+                    const fresh = await ApiClient.getPluginConfiguration(pluginId);
+                    CUSTOM_TAB_MANAGED_ENTRIES.forEach(function(entry) {
+                        _jeCustomTabOwnedCache[entry.ownedKey] = fresh[entry.ownedKey] === true;
+                    });
+                } catch (reloadErr) {
+                    console.error('[JE] Cache rollback after owned-flag persist failure also failed:', reloadErr);
+                }
+                // Downgrade the result so saveConfig's check surfaces the partial.
+                // The recovery message has to be specific because the trivial "re-save"
+                // path does not actually repair the state: post-rollback the cache and
+                // server agree on owned=false, the CT entry exists, and the next sync's
+                // shouldExist+entry-exists branch will preserve owned=false (no second
+                // write fires). Real recovery is to delete the CT entry from the
+                // Custom Tabs plugin UI and then re-save here so the next sync ADDs
+                // a fresh entry and stamps it owned=true.
+                return Object.assign({}, syncResult, {
+                    ok: false,
+                    status: 'partial',
+                    detail: (syncResult.detail ? syncResult.detail + ' — ' : '') +
+                            "Custom Tabs has the new entry, but Jellyfin Enhanced could not save its ownership record. " +
+                            "JE will not be able to clean this entry up on a later toggle change. " +
+                            "To restore JE management: open the Custom Tabs plugin, delete the JE-managed entry there, then save this page again — JE will recreate it and record ownership properly."
+                });
+            }
+        }
+
+        // Re-entrancy guard. `Dashboard.showLoadingMsg()` provides only a visual
+        // overlay, not an input block, so two rapid Enter presses or a second
+        // click on the save dock can still fire saveConfig in parallel — the
+        // second one's `buildConfigFromForm` reads a server state that the
+        // first one has already mutated, and Save#1's deferred owned-flag write
+        // (step 2) can land after Save#2 and silently revert the admin's
+        // between-save form changes. Treat saves as serial.
+        var _jeSaveInFlight = false;
+
         async function saveConfig(e) {
             e.preventDefault();
+            if (_jeSaveInFlight) return false;
+            _jeSaveInFlight = true;
             Dashboard.showLoadingMsg();
+            var saveBtns = document.querySelectorAll('.je-save-dock-btn');
+            saveBtns.forEach(function(b) { b.disabled = true; });
 
             try {
                 const config = await buildConfigFromForm();
                 const result = await ApiClient.updatePluginConfiguration(pluginId, config);
+                // After JE config is persisted, sync any managed Custom Tabs entries.
+                // We surface non-OK results to the admin via Dashboard.alert so a
+                // partial failure doesn't hide behind the green "saved" toast.
+                const syncResult = await runCustomTabsSync(config);
                 Dashboard.processPluginConfigurationUpdateResult(result);
-            } catch {
+                if (syncResult && syncResult.ok === false) {
+                    try {
+                        Dashboard.alert({
+                            title: 'Custom Tabs sync issue',
+                            message: 'Your Jellyfin Enhanced settings were saved, but the Custom Tabs entry could not be updated.\n\n' +
+                                     (syncResult.detail || 'See browser console for details.')
+                        });
+                    } catch (alertErr) { console.warn('[JE] Dashboard.alert threw:', alertErr); }
+                }
+            } catch (saveErr) {
                 Dashboard.hideLoadingMsg();
+                console.error('[JE] saveConfig failed:', saveErr);
+                try {
+                    Dashboard.alert({
+                        title: 'Save failed',
+                        message: 'Could not save Jellyfin Enhanced settings. Check the browser console and server logs, then try again.'
+                    });
+                } catch (alertErr) { console.warn('[JE] Dashboard.alert threw:', alertErr); }
+            } finally {
+                _jeSaveInFlight = false;
+                saveBtns.forEach(function(b) { b.disabled = false; });
             }
             return false;
         }
 
         // Saves current config and applies it to all users
         async function resetAllUserSettings() {
-            if (confirm("Are you sure?\n\nThis will save the current configuration overwriting the above settings to ALL users on this server.")) {
+            if (confirm("Are you sure?\n\nThis will save the current configuration and overwrite every per-user default for ALL users on this server.")) {
                 Dashboard.showLoadingMsg();
                 try {
                     // First, save the current configuration
                     const config = await buildConfigFromForm();
                     await ApiClient.updatePluginConfiguration(pluginId, config);
+
+                    // Sync managed Custom Tabs entries — same flow as a normal save,
+                    // so "Apply to all users" doesn't silently skip the side-effect.
+                    const syncResult = await runCustomTabsSync(config);
 
                     // Then reset all user settings to match the saved config
                     await ApiClient.ajax({
@@ -3247,10 +4146,11 @@
                     });
 
                     Dashboard.hideLoadingMsg();
-                    Dashboard.alert({
-                        title: 'Success',
-                        message: 'Configuration saved and applied to all users successfully!\n\nSettings will take effect after users refresh their browsers.'
-                    });
+                    let msg = 'Configuration saved and applied to all users successfully!\n\nSettings will take effect after users refresh their browsers.';
+                    if (syncResult && syncResult.ok === false) {
+                        msg += '\n\n(Custom Tabs sync did not complete: ' + (syncResult.detail || 'see console') + ')';
+                    }
+                    Dashboard.alert({ title: 'Success', message: msg });
                 } catch (e) {
                     Dashboard.hideLoadingMsg();
                     console.error('Failed to save and apply settings:', e);
@@ -3296,19 +4196,19 @@
                 // Drag and drop
                 dropZone.addEventListener('dragover', (e) => {
                     e.preventDefault();
-                    dropZone.style.borderColor = '#00a4dc';
-                    dropZone.style.backgroundColor = 'rgba(0,164,220,0.1)';
+                    dropZone.style.borderColor = 'var(--primary-accent-color, #00a4dc)';
+                    dropZone.style.backgroundColor = 'color-mix(in srgb, var(--primary-accent-color, #00a4dc) 10%, transparent)';
                 });
 
                 dropZone.addEventListener('dragleave', (e) => {
                     e.preventDefault();
-                    dropZone.style.borderColor = 'rgba(0,164,220,0.5)';
+                    dropZone.style.borderColor = 'color-mix(in srgb, var(--primary-accent-color, #00a4dc) 50%, transparent)';
                     dropZone.style.backgroundColor = 'rgba(255,255,255,0.05)';
                 });
 
                 dropZone.addEventListener('drop', (e) => {
                     e.preventDefault();
-                    dropZone.style.borderColor = 'rgba(0,164,220,0.5)';
+                    dropZone.style.borderColor = 'color-mix(in srgb, var(--primary-accent-color, #00a4dc) 50%, transparent)';
                     dropZone.style.backgroundColor = 'rgba(255,255,255,0.05)';
                     if (e.dataTransfer.files.length > 0) {
                         uploadBrandingImage(e.dataTransfer.files[0], config, statusDiv);
@@ -3556,6 +4456,32 @@
         resetAllUserSettingsBtn.addEventListener('click', resetAllUserSettings);
         initAutoMovieQualityMode();
 
+        // Live-update the Requests Page requirements banner as the admin types
+        // into Seerr fields or adds/edits/removes *arr instances. Delegated on
+        // the form so it also covers dynamically-created instance cards.
+        (function wireRequestsBannerReactive() {
+            var formEl = document.getElementById('JellyfinEnhancedForm');
+            if (!formEl) return;
+            function relevant(target) {
+                if (!target) return false;
+                if (target.id === 'jellyseerrUrls' || target.id === 'JellyseerrApiKey') return true;
+                if (target.classList && (target.classList.contains('arr-instance-url') || target.classList.contains('arr-instance-apikey'))) return true;
+                return false;
+            }
+            formEl.addEventListener('input', function(e) {
+                if (relevant(e.target)) updateRequestsRequirementsBanner();
+            });
+            // Instance add/remove happens via button clicks that mutate
+            // #sonarrInstancesList / #radarrInstancesList. Observe both so the
+            // banner updates immediately on remove (no input event fires).
+            ['sonarrInstancesList', 'radarrInstancesList'].forEach(function(id) {
+                var root = document.getElementById(id);
+                if (!root) return;
+                new MutationObserver(updateRequestsRequirementsBanner)
+                    .observe(root, { childList: true, subtree: true });
+            });
+        })();
+
         // ================================
         // SETTING DEPENDENCY SYSTEM
         // ================================
@@ -3595,7 +4521,7 @@
 
         var SECTION_DEPS = [
             {
-                tabSelector: '#jellyseerr',
+                tabSelector: '#seerr',
                 skipFirst: true,
                 checkFn: hasJellyseerrConfigured,
                 bannerIcon: 'link_off',
@@ -3604,7 +4530,7 @@
                 bannerId: 'dep-banner-jellyseerr'
             },
             {
-                tabSelector: '#arr-links',
+                tabSelector: '#arr',
                 skipFirst: true,
                 checkFn: hasAnyArrService,
                 bannerIcon: 'link_off',
@@ -3802,10 +4728,10 @@
             { parent: 'showUserReviews', label: 'Enable User Reviews', children: ['hideReviewsFromHiddenUsers', 'hideReviewsFromDisabledUsers'] },
             { parent: 'randomButtonEnabled', label: 'Enable Random Button', children: ['randomUnwatchedOnly', 'randomIncludeMovies', 'randomIncludeShows'] },
             { parent: 'showWatchProgress', label: 'Show watch progress', children: ['watchProgressDefaultMode', 'watchProgressTimeFormat'] },
-            { parent: 'qualityTagsEnabled', label: 'Enable Quality Tags', children: ['qualityTagsPosition'] },
-            { parent: 'genreTagsEnabled', label: 'Enable Genre Tags', children: ['genreTagsPosition'] },
-            { parent: 'languageTagsEnabled', label: 'Enable Language Tags', children: ['languageTagsPosition'] },
-            { parent: 'ratingTagsEnabled', label: 'Enable Rating Tags', children: ['ratingTagsPosition'] },
+            { parent: 'qualityTagsEnabled', label: 'Enable Quality Tags', children: ['qualityTagsPosition'], noHint: true },
+            { parent: 'genreTagsEnabled', label: 'Enable Genre Tags', children: ['genreTagsPosition'], noHint: true },
+            { parent: 'languageTagsEnabled', label: 'Enable Language Tags', children: ['languageTagsPosition'], noHint: true },
+            { parent: 'ratingTagsEnabled', label: 'Enable Rating Tags', children: ['ratingTagsPosition'], noHint: true },
             { parent: 'useIcons', label: 'Use Icons', children: ['iconStyle'] },
             { parent: 'letterboxdEnabled', label: 'Enable Letterboxd', children: ['showLetterboxdLinkAsText'] },
             { parent: 'enableCustomSplashScreen', label: 'Enable Custom Splash Screen', children: ['splashScreenImageUrl'] },
@@ -3849,8 +4775,10 @@
                         container.style.opacity = '0.5';
                         container.style.cursor = 'not-allowed';
                         addDepTag(container, tag);
-                        // Add hint if not present
-                        if (!container.querySelector('.' + hintClass)) {
+                        // Add hint unless the dependency opted out (e.g. tag-position
+                        // dropdowns, where the disabled styling next to the parent
+                        // checkbox already makes the relationship obvious).
+                        if (!dep.noHint && !container.querySelector('.' + hintClass)) {
                             var hint = document.createElement('div');
                             hint.className = 'dep-hint-text ' + hintClass;
                             hint.textContent = 'Enable "' + dep.label + '" to configure';
@@ -3871,15 +4799,876 @@
             });
         }
 
+        // ==============================================================
+        // Connection-test cache + Integration Health checklist (phase 4).
+        // The checklist on Overview is a live health view of every
+        // integration the admin has turned on. It renders rows purely
+        // from (live config) + (cached test results), so it doesn't
+        // hammer external services on every render. TTL keeps results
+        // fresh without forcing probes on every click. The "Re-test all"
+        // Quick Action clears the cache and re-invokes every test.
+        // ==============================================================
+        var CONNECTION_TEST_CACHE_TTL_MS = 5 * 60 * 1000;
+        var _jeConnectionTestCache = new Map();
+
+        // Generation counter for the cache. Every clear bumps it; any
+        // write that was captured (via beginConnectionTest) at a prior
+        // generation is dropped. Closes the race where a user clicks a
+        // per-service Test button, then clicks Re-test-all, then the
+        // original click's async result resolves and writes a stale
+        // ok/error over the fresh result. See design review H2.
+        var _jeCacheGeneration = 0;
+
+        /**
+         * Capture the current cache generation. Tests call this at START
+         * and pass the returned token to setConnectionTestResult. A token
+         * older than the current generation means the cache was cleared
+         * mid-test and this write is stale — it gets dropped.
+         */
+        function beginConnectionTest() {
+            return _jeCacheGeneration;
+        }
+
+        // When true, per-service tests skip their own Dashboard.alert
+        // success/failure dialog. The Re-test-all Quick Action sets this
+        // for the duration of a batch and shows a single aggregate dialog
+        // at the end, instead of stacking 8+ modal prompts the admin has
+        // to dismiss one by one.
+        var _jeSuppressTestAlerts = false;
+
+        /**
+         * Dashboard.alert that respects the batch-mode suppression flag.
+         * Use inside any per-service test function where a Dashboard.alert
+         * is part of the individual-test UX but would spam the admin when
+         * the test fires as part of a batch re-test.
+         */
+        function jeTestAlert(opts) {
+            if (_jeSuppressTestAlerts) return;
+            try { Dashboard.alert(opts); } catch (e) {
+                console.warn('[JE] Dashboard.alert threw:', e);
+            }
+        }
+
+        /**
+         * Write a test result into the cache and refresh the checklist.
+         * Safe to call multiple times; last write wins within the same
+         * generation. Cache-refresh is guarded against exceptions so a
+         * bug in renderChecklist can't cascade and break the actual
+         * test flow.
+         * @param {string} key  e.g. 'tmdb', 'seerr', 'sonarr:<normalizedUrl>'
+         * @param {'ok'|'error'} status
+         * @param {string} detail short human message shown in the row
+         * @param {number} [token] optional generation token from
+         *   beginConnectionTest; stale tokens are silently dropped.
+         */
+        function setConnectionTestResult(key, status, detail, token) {
+            if (token !== undefined && token !== _jeCacheGeneration) {
+                // Stale write from a test that was issued before the last
+                // cache clear. Drop it so a fresher (in-flight) test's
+                // result isn't overwritten by a stale ok/error.
+                return;
+            }
+            var now = Date.now();
+            _jeConnectionTestCache.set(key, {
+                status: status,
+                detail: detail || '',
+                at: now
+            });
+            // Also persist to localStorage so the checklist can show "Last
+            // tested <date>" after a page reload, instead of falling back
+            // to "Configured — not yet verified" as if nothing was ever
+            // checked. Wrapped in try/catch because localStorage is
+            // best-effort (private mode, quota, disabled storage, etc.).
+            try {
+                localStorage.setItem('je_conn_test_' + key, JSON.stringify({
+                    status: status,
+                    detail: detail || '',
+                    at: now
+                }));
+            } catch (e) { /* persistence is best-effort */ }
+            try { renderChecklist(); } catch (e) {
+                console.warn('[JE] renderChecklist threw after setConnectionTestResult:', e);
+            }
+        }
+
+        /**
+         * Read a previously-persisted test result for a connection key.
+         * Returns null if no record, malformed JSON, or storage unavailable.
+         * Unlike the in-memory cache there is NO TTL — the persisted entry
+         * is meant to outlive page reloads so the admin always sees the
+         * date of the most recent verification, however long ago it was.
+         */
+        function getPersistedTestResult(key) {
+            var storageKey = 'je_conn_test_' + key;
+            try {
+                var raw = localStorage.getItem(storageKey);
+                if (!raw) return null;
+                var rec = JSON.parse(raw);
+                if (!rec || typeof rec.at !== 'number' || typeof rec.status !== 'string') {
+                    // Self-heal: drop the bad entry so subsequent renders don't keep
+                    // re-parsing it and so the row falls cleanly back to "not tested".
+                    try { localStorage.removeItem(storageKey); } catch (e) {}
+                    return null;
+                }
+                return rec;
+            } catch (e) {
+                // Parse error → treat as corrupt and remove.
+                try { localStorage.removeItem(storageKey); } catch (rmErr) {}
+                return null;
+            }
+        }
+
+        /**
+         * Format a timestamp for the checklist's "Last tested" line:
+         *   - same day  → "Last tested 3:45 PM"
+         *   - other day → "Last tested Apr 20, 2026"
+         */
+        function formatLastTested(ts) {
+            var d = new Date(ts);
+            var now = new Date();
+            if (d.toDateString() === now.toDateString()) {
+                return 'Last tested ' + d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+            }
+            return 'Last tested ' + d.toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' });
+        }
+
+        /**
+         * Build a checklist row from cached / persisted test data.
+         *  - Fresh in-memory hit  → row reflects the live status + detail
+         *  - Persisted-only hit   → row keeps the last known state but
+         *    swaps the detail line for "Last tested <date>"
+         *  - No data              → row stays 'pending' with the supplied
+         *    fallback text
+         */
+        function checklistRowState(cacheKey, fallbackDetail) {
+            var live = getConnectionTestResult(cacheKey);
+            if (live) return { state: live.status, detail: live.detail };
+            var persisted = getPersistedTestResult(cacheKey);
+            if (persisted) return { state: persisted.status, detail: formatLastTested(persisted.at) };
+            return { state: 'pending', detail: fallbackDetail };
+        }
+
+        /**
+         * Read a test result from the cache. Returns null on miss OR on
+         * expiry — callers render the row as "pending" in that case.
+         */
+        function getConnectionTestResult(key) {
+            var entry = _jeConnectionTestCache.get(key);
+            if (!entry) return null;
+            if (Date.now() - entry.at > CONNECTION_TEST_CACHE_TTL_MS) {
+                _jeConnectionTestCache.delete(key);
+                return null;
+            }
+            return entry;
+        }
+
+        /**
+         * Drop every cached result. Used by the Re-test-all Quick Action
+         * so rows immediately show "pending" while tests fire.
+         */
+        function clearConnectionTestCache() {
+            _jeConnectionTestCache.clear();
+            _jeCacheGeneration++;
+            // Also drop persisted entries; otherwise checklistRowState falls back
+            // to the "Last tested <date>" line and rows stay green/red instead of
+            // showing pending while the new tests fire.
+            try {
+                var doomed = [];
+                for (var i = 0; i < localStorage.length; i++) {
+                    var k = localStorage.key(i);
+                    if (k && k.indexOf('je_conn_test_') === 0) doomed.push(k);
+                }
+                doomed.forEach(function(k) { localStorage.removeItem(k); });
+            } catch (e) { /* private mode / quota — best-effort */ }
+            try { renderChecklist(); } catch (e) {
+                console.warn('[JE] renderChecklist threw after clearConnectionTestCache:', e);
+            }
+        }
+
+        /**
+         * Drop the persisted "Last tested <date>" entry for a given service when
+         * the inputs that produced that test result change (new TMDB key, new Seerr
+         * URL, etc.) — otherwise the checklist would keep claiming the old key
+         * worked. Wired up in the load/change handlers for the relevant inputs.
+         */
+        function invalidatePersistedTest(key) {
+            try { localStorage.removeItem('je_conn_test_' + key); } catch (e) {}
+            // Clear in-memory copy too so the row immediately drops to pending.
+            _jeConnectionTestCache.delete(key);
+            try { renderChecklist(); } catch (e) {}
+        }
+
+        /**
+         * Normalize an arr-instance URL into a cache key fragment.
+         * Trim, lowercase, strip trailing slashes so minor differences
+         * don't fork the cache.
+         */
+        function _jeNormalizeArrUrl(url) {
+            return (url || '').trim().toLowerCase().replace(/\/+$/, '');
+        }
+
+        /**
+         * Build the Integration Health checklist inside #je-checklist.
+         *
+         * Row rules:
+         *   - Only render a row when the integration is enabled.
+         *   - Row state: 'ok' (green), 'amber' (warn), 'error' (red),
+         *     'pending' (grey — enabled + complete config but no cached
+         *     test result within TTL).
+         *   - Zero rows is a valid outcome — render the empty hint.
+         *   - Clicking a row jumps to the target tab.
+         *
+         * No HTML is injected from runtime data — every row is built with
+         * createElement + textContent so untrusted instance names / URLs
+         * can never inject markup into the checklist.
+         */
+        function renderChecklist() {
+            // Thin delegator: the Integration Health checklist was merged into
+            // Service Status, but multiple callers still reference this name —
+            // keep the symbol to avoid breaking them. The original per-row
+            // construction (#je-checklist + .je-checklist-* classes) was
+            // removed along with its DOM host and CSS.
+            renderServiceStatusDashboard();
+        }
+
+        /**
+         * Overview → Optional Dependencies
+         * Renders a card per optional plugin with its detected state.
+         * Sources the booleans populated by checkInstalledPlugins() —
+         * `null` means the /Plugins probe hasn't completed (or failed),
+         * rendered as "Checking…" rather than asserting missing.
+         */
+        var OPTIONAL_PLUGINS = [
+            { key: 'fileTransformation', name: 'File Transformation', icon: 'transform',       url: 'https://github.com/IAmParadox27/jellyfin-plugin-file-transformation', purpose: 'Required for custom splash screens, branding images, and media bar integration.', getFlag: function(){ return hasFileTransformation; } },
+            { key: 'pluginPages',        name: 'Plugin Pages',        icon: 'view_list',       url: 'https://github.com/IAmParadox27/jellyfin-plugin-pages',               purpose: 'Sidebar pages for Bookmarks, Hidden Content, Requests, Calendar.',                   getFlag: function(){ return hasPluginPages; } },
+            { key: 'customTabs',         name: 'Custom Tabs',         icon: 'tab',             url: 'https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs',         purpose: 'Home-page tab entries for Bookmarks, Hidden Content, Requests, Calendar.',          getFlag: function(){ return hasCustomTabs; } },
+            { key: 'introSkipper',       name: 'Intro Skipper',       icon: 'skip_next',       url: 'https://github.com/intro-skipper/intro-skipper',                      purpose: 'Source of timestamps for Auto-skip Intro / Auto-skip Outro.',                        getFlag: function(){ return hasIntroSkipper; } },
+            { key: 'kefinTweaks',        name: 'KefinTweaks',         icon: 'bookmark_border', url: 'https://github.com/ranaldsgift/KefinTweaks',                          purpose: 'Renders the Watchlist UI in Jellyfin. Required to view watchlisted items from the Seerr Watchlist features. Installs as a web-mod (not a normal plugin), detected via its injected scripts.', getFlag: function(){ return hasKefinTweaks; } }
+        ];
+        function renderOptionalPluginsDashboard() {
+            var root = document.getElementById('je-optional-plugins');
+            if (!root) return;
+            root.textContent = '';
+            OPTIONAL_PLUGINS.forEach(function(dep) {
+                var flag = dep.getFlag();
+                var state, statusText;
+                if (flag === true)       { state = 'installed'; statusText = 'Installed'; }
+                else if (flag === false) { state = 'missing';   statusText = 'Not installed'; }
+                else                     { state = 'unknown';   statusText = 'Checking…'; }
+
+                // When the plugin is installed-but-disabled (status ≠ Active),
+                // flip to an amber "disabled" state so the admin knows to
+                // re-enable it rather than wonder why features don't work.
+                if (flag === false && _jeDisabledPlugins[dep.key]) {
+                    state = 'warn';
+                    statusText = 'Installed but disabled in Dashboard > Plugins';
+                }
+
+                // Only surface a compat warning for Custom Tabs when we've
+                // actually completed the probe — not while it's still pending
+                // (customTabsCompatState === null). This avoids a transient
+                // "incompatible" flash during the initial load.
+                if (dep.key === 'customTabs' && flag === true) {
+                    if (customTabsCompatState === 'incompatible') {
+                        state = 'warn';
+                        statusText = 'Installed — config shape not recognized (auto-create disabled)';
+                    } else if (customTabsCompatState === 'probe-failed') {
+                        state = 'warn';
+                        statusText = "Installed — couldn't read config (auto-create disabled)";
+                    } else if (customTabsCompatState === null) {
+                        statusText = 'Installed — checking config…';
+                    }
+                }
+                var card = document.createElement('div');
+                card.className = 'je-optional-plugin-card je-state-' + state;
+                var icon = document.createElement('i');
+                icon.className = 'material-icons je-optional-plugin-icon';
+                icon.setAttribute('aria-hidden', 'true');
+                icon.textContent = state === 'installed' ? 'check_circle'
+                                 : state === 'warn'      ? 'warning'
+                                 : state === 'unknown'   ? 'help_outline'
+                                 : 'radio_button_unchecked';
+                card.appendChild(icon);
+                var body = document.createElement('div');
+                body.className = 'je-optional-plugin-body';
+                var name = document.createElement('div');
+                name.className = 'je-optional-plugin-name';
+                name.textContent = dep.name;
+                body.appendChild(name);
+                var status = document.createElement('div');
+                status.className = 'je-optional-plugin-status';
+                status.textContent = statusText;
+                body.appendChild(status);
+                var purpose = document.createElement('div');
+                purpose.className = 'je-optional-plugin-purpose';
+                purpose.textContent = dep.purpose;
+                body.appendChild(purpose);
+                card.appendChild(body);
+
+                // External link icon in the top-right — opens the plugin's
+                // home repo in a new tab. noopener/noreferrer both for security
+                // and so the opened page can't manipulate this window.
+                if (dep.url) {
+                    var link = document.createElement('a');
+                    link.className = 'je-optional-plugin-link';
+                    link.href = dep.url;
+                    link.target = '_blank';
+                    link.rel = 'noopener noreferrer';
+                    link.title = 'Open ' + dep.name + ' on GitHub';
+                    link.setAttribute('aria-label', 'Open ' + dep.name + ' on GitHub');
+                    var linkIcon = document.createElement('i');
+                    linkIcon.className = 'material-icons';
+                    linkIcon.setAttribute('aria-hidden', 'true');
+                    linkIcon.textContent = 'open_in_new';
+                    link.appendChild(linkIcon);
+                    card.appendChild(link);
+                }
+
+                root.appendChild(card);
+            });
+        }
+
+        /**
+         * Overview → Features
+         * Renders a row per JE feature with one of three states:
+         *   - on   (green)   : enabled and all required deps/config present
+         *   - warn (amber)   : enabled but missing a dep or required config
+         *   - off  (faded)   : disabled
+         * Clicking a row jumps to the tab where the feature lives.
+         *
+         * Rules reference form inputs (live DOM) rather than a snapshot so this
+         * updates correctly after every dependency re-evaluation.
+         */
+        function renderFeaturesDashboard() {
+            var root = document.getElementById('je-features-dashboard');
+            if (!root) return;
+
+            function bool(id) {
+                var el = document.getElementById(id);
+                return !!(el && el.checked);
+            }
+            function val(id) {
+                var el = document.getElementById(id);
+                return el ? (el.value || '').trim() : '';
+            }
+            function anyArrConfigured() {
+                var cards = document.querySelectorAll('#sonarrInstancesList .arr-instance-card, #radarrInstancesList .arr-instance-card');
+                for (var i = 0; i < cards.length; i++) {
+                    var url = cards[i].querySelector('.arr-instance-url');
+                    var key = cards[i].querySelector('.arr-instance-apikey');
+                    if (url && key && url.value.trim() && key.value.trim()) return true;
+                }
+                return false;
+            }
+            function seerrConfigured() {
+                return !!val('jellyseerrUrls') && !!val('JellyseerrApiKey');
+            }
+
+            var features = [];
+            function feat(name, enabled, tab, detail, warn) {
+                if (!enabled) { features.push({ name: name, state: 'off', tab: tab, detail: 'Disabled' }); return; }
+                features.push({ name: name, state: warn ? 'warn' : 'on', tab: tab, detail: detail });
+            }
+
+            // Display
+            feat('Remove from Continue Watching', bool('removeContinueWatchingEnabled'), 'display', 'Enabled');
+            var tagCount = ['qualityTagsEnabled','genreTagsEnabled','languageTagsEnabled','ratingTagsEnabled','peopleTagsEnabled'].filter(bool).length;
+            feat('Media Tags', tagCount > 0, 'display', tagCount + ' tag type(s) enabled');
+            feat('Random Button', bool('randomButtonEnabled'), 'display', 'Enabled');
+
+            // Playback
+            feat('Custom Pause Screen', bool('pauseScreenEnabled'), 'playback', 'Enabled');
+            feat('Long press for 2x speed', bool('longPress2xEnabled'), 'playback', 'Enabled (touch devices)');
+            var autoSkip = bool('autoSkipIntro') || bool('autoSkipOutro');
+            var autoSkipWarn = autoSkip && hasIntroSkipper !== true;
+            feat('Auto-skip Intro/Outro', autoSkip, 'playback',
+                autoSkipWarn ? 'Enabled but Intro Skipper plugin is missing' : 'Enabled',
+                autoSkipWarn);
+            var tabSwitch = bool('autoPauseEnabled') || bool('autoResumeEnabled') || bool('autoPipEnabled');
+            feat('Tab-switch actions', tabSwitch, 'playback', 'Auto-pause / resume / PiP');
+
+            // Pages
+            var bookmarksWarn = bool('bookmarksEnabled') && (
+                (bool('bookmarksUsePluginPages') && hasPluginPages !== true) ||
+                (bool('bookmarksUseCustomTabs')  && hasCustomTabs  !== true)
+            );
+            feat('Bookmarks', bool('bookmarksEnabled'), 'pages',
+                bookmarksWarn ? 'Missing required integration plugin' : 'Enabled',
+                bookmarksWarn);
+            var hcWarn = bool('hiddenContentEnabled') && (
+                (bool('hiddenContentUsePluginPages') && hasPluginPages !== true) ||
+                (bool('hiddenContentUseCustomTabs')  && hasCustomTabs  !== true)
+            );
+            feat('Hidden Content', bool('hiddenContentEnabled'), 'pages',
+                hcWarn ? 'Missing required integration plugin' : 'Enabled',
+                hcWarn);
+            var reqWarn = bool('downloadsPageEnabled') && !seerrConfigured() && !anyArrConfigured();
+            feat('Requests Page', bool('downloadsPageEnabled'), 'pages',
+                reqWarn ? 'Enabled but neither Seerr nor *arr is configured' : 'Enabled',
+                reqWarn);
+            var calWarn = bool('calendarPageEnabled') && !anyArrConfigured();
+            feat('Calendar Page', bool('calendarPageEnabled'), 'pages',
+                calWarn ? 'Enabled but no *arr instance is configured' : 'Enabled',
+                calWarn);
+
+            // Custom splash screen / branding. Splash-screen URL works without
+            // any extra plugin, but the branding image uploads (icons/favicon/
+            // logos) require File Transformation to actually replace the web
+            // assets — surface a warning when the splash is enabled and File
+            // Transformation is missing.
+            var splashOn = bool('enableCustomSplashScreen');
+            var splashWarn = splashOn && hasFileTransformation !== true;
+            feat('Custom splash / branding', splashOn, 'extras',
+                splashWarn ? 'Enabled but File Transformation plugin missing (uploaded images won\'t apply)' : 'Enabled',
+                splashWarn);
+
+            // Extras
+            var elsewhereWarn = bool('elsewhereEnabled') && !val('TMDB_API_KEY');
+            feat('Elsewhere (streaming providers)', bool('elsewhereEnabled'), 'elsewhere',
+                elsewhereWarn ? 'Enabled but TMDB API key is missing' : 'Enabled',
+                elsewhereWarn);
+
+            // Seerr
+            var seerrWarn = bool('jellyseerrEnabled') && !seerrConfigured();
+            feat('Seerr integration', bool('jellyseerrEnabled'), 'seerr',
+                seerrWarn ? 'Enabled but Seerr URL or API key missing' : 'Enabled',
+                seerrWarn);
+
+            // Watchlist (Seerr tab). Sync and "add requested → watchlist" both
+            // need KefinTweaks to actually render the watchlist UI in Jellyfin;
+            // the feature writes the data either way, but the user can't see
+            // it without KefinTweaks.
+            var watchlistAny = bool('addRequestedMediaToWatchlist') || bool('syncJellyseerrWatchlist');
+            var watchlistWarn = watchlistAny && hasKefinTweaks !== true;
+            feat('Watchlist sync', watchlistAny, 'seerr',
+                watchlistWarn ? 'Enabled but KefinTweaks plugin not installed (watchlist UI won\'t render)' : 'Enabled',
+                watchlistWarn);
+
+            // *arr
+            var arrLinksWarn = bool('arrLinksEnabled') && !anyArrConfigured();
+            feat('*arr detail-page links', bool('arrLinksEnabled'), 'arr',
+                arrLinksWarn ? 'Enabled but no *arr instance is configured' : 'Enabled',
+                arrLinksWarn);
+            var tagsSyncWarn = bool('arrTagsSyncEnabled') && !anyArrConfigured();
+            feat('*arr tags sync', bool('arrTagsSyncEnabled'), 'arr',
+                tagsSyncWarn ? 'Enabled but no *arr instance is configured' : 'Enabled',
+                tagsSyncWarn);
+
+            // Stable ordering: warnings first, then on, then off
+            features.sort(function(a, b) {
+                var ord = { warn: 0, on: 1, off: 2 };
+                return ord[a.state] - ord[b.state];
+            });
+
+            root.textContent = '';
+            if (features.length === 0) {
+                var empty = document.createElement('div');
+                empty.className = 'je-checklist-empty';
+                empty.textContent = 'No features configured yet.';
+                root.appendChild(empty);
+                return;
+            }
+            features.forEach(function(f) {
+                var row = document.createElement('button');
+                row.type = 'button';
+                row.className = 'je-feature-row je-state-' + f.state;
+                row.setAttribute('data-target', f.tab);
+                var icon = document.createElement('i');
+                icon.className = 'material-icons je-feature-icon';
+                icon.setAttribute('aria-hidden', 'true');
+                icon.textContent = f.state === 'on'   ? 'check_circle'
+                                 : f.state === 'warn' ? 'warning'
+                                 : 'radio_button_unchecked';
+                row.appendChild(icon);
+                var body = document.createElement('div');
+                body.className = 'je-feature-body';
+                var name = document.createElement('div');
+                name.className = 'je-feature-name';
+                name.textContent = f.name;
+                body.appendChild(name);
+                var detail = document.createElement('div');
+                detail.className = 'je-feature-detail';
+                detail.textContent = f.detail;
+                body.appendChild(detail);
+                row.appendChild(body);
+                row.addEventListener('click', function() {
+                    var targetTab = f.tab;
+                    var tabBtn = document.querySelector('.jellyfin-tab-button[data-tab="' + targetTab + '"]');
+                    if (tabBtn) tabBtn.click();
+                });
+                root.appendChild(row);
+            });
+        }
+
+        // ==============================================================
+        // Gated help (phase 5). Any setup-instruction block that only
+        // applies when a specific toggle is on lives under a
+        // [data-gated-by="<checkbox-id>"] attribute. Hidden when the
+        // toggle is off; visible when on. Transitions from off→on also
+        // auto-open the accordion so the admin doesn't have to hunt
+        // for the freshly-revealed help.
+        //
+        // Declarative tag + generic dispatcher = no per-section wiring.
+        // Adding a new gated help block means: drop data-gated-by on
+        // the element + add the checkbox id below to GATED_HELP_IDS.
+        // ==============================================================
+
+        // Track prior checked state per gated-help parent so we can
+        // detect an off→on transition in the change listener and
+        // auto-expand the just-revealed accordion.
+        var _jeGatedHelpState = Object.create(null);
+
+        /**
+         * Syncs visibility of every [data-gated-by] element to its
+         * parent checkbox's checked state. If autoExpandOnRise is true
+         * AND a parent just went from unchecked to checked, the gated
+         * `<details>` is auto-opened.
+         */
+        function applyGatedHelp(autoExpandOnRise) {
+            var gated = document.querySelectorAll('[data-gated-by]');
+            gated.forEach(function(el) {
+                var parentAttr = el.getAttribute('data-gated-by');
+                if (!parentAttr) return;
+                // Allow comma-separated IDs: ALL listed parents must be checked
+                // for the gated element to show. Used by Custom Tabs auto-manage
+                // toggles which depend on BOTH `*UseCustomTabs` AND the master
+                // `*Enabled` toggle for the feature.
+                var parentIds = parentAttr.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
+                var allOn = true;
+                var anyRise = false;
+                parentIds.forEach(function(parentId) {
+                    var parent = document.getElementById(parentId);
+                    if (!parent) { allOn = false; return; }
+                    var thisOn = !!parent.checked;
+                    if (!thisOn) allOn = false;
+                    var wasOn = _jeGatedHelpState[parentId] === true;
+                    if (thisOn && !wasOn) anyRise = true;
+                    _jeGatedHelpState[parentId] = thisOn;
+                });
+                el.hidden = !allOn;
+                if (autoExpandOnRise && allOn && anyRise && el.tagName === 'DETAILS') {
+                    el.open = true;
+                }
+            });
+        }
+
+        // Wire one change listener per unique parent id referenced by
+        // [data-gated-by]. A single bulk dispatch refreshes every gated
+        // element regardless of which parent fired.
+        //
+        // We also prime `_jeGatedHelpState` with each parent's current
+        // checked value at wire time. Without priming, the first user
+        // click on a gated parent that was already checked (e.g. after a
+        // config load flipped the DOM state out of band) would be read
+        // as `wasOn === undefined (falsy) → isOn === true`, i.e. a rise,
+        // and auto-expand when it shouldn't. Priming closes that hole
+        // for the initial render AND for any parent the config loader
+        // set programmatically (programmatic `.checked = true` does NOT
+        // fire a change event, so the listener wouldn't see it).
+        (function wireGatedHelp() {
+            var gated = document.querySelectorAll('[data-gated-by]');
+            var uniqueParents = Object.create(null);
+            gated.forEach(function(el) {
+                var attr = el.getAttribute('data-gated-by');
+                if (!attr) return;
+                attr.split(',').map(function(s) { return s.trim(); }).filter(Boolean).forEach(function(id) {
+                    uniqueParents[id] = true;
+                });
+            });
+            Object.keys(uniqueParents).forEach(function(id) {
+                var parent = document.getElementById(id);
+                if (!parent) {
+                    console.warn('[JE] gated-help: parent checkbox #' + id + ' not found — help will stay hidden');
+                    return;
+                }
+                _jeGatedHelpState[id] = !!parent.checked;
+                parent.addEventListener('change', function() {
+                    try { applyGatedHelp(true); } catch (e) {
+                        console.warn('[JE] applyGatedHelp threw in change handler:', e);
+                    }
+                });
+            });
+            // Reflect initial visibility once so the DOM matches the primed
+            // state immediately (no flicker when loadConfig eventually
+            // triggers updateAllDependencies → applyGatedHelp(false)).
+            try { applyGatedHelp(false); } catch (e) {
+                console.warn('[JE] applyGatedHelp threw during init:', e);
+            }
+        })();
+
         /**
          * Orchestrator: evaluates all section, individual, and parent dependency rules.
+         * Each step is isolated so a throw in the status dashboard (which reads a lot
+         * of field values) can't cascade and break dependency updates.
          */
         function updateAllDependencies() {
             SECTION_DEPS.forEach(updateSectionDep);
             INDIVIDUAL_DEPS.forEach(updateIndividualDep);
             PARENT_DEPS.forEach(updateParentDep);
             updateClientTagCacheControlsVisibility();
+            // `updateStatusDashboard` and the legacy `renderChecklist` both
+            // now delegate to `renderServiceStatusDashboard`. Calling both
+            // here would rebuild the service grid TWICE per dependency tick
+            // (~30 times during a TMDB key rotation). One call is enough.
+            try {
+                renderServiceStatusDashboard();
+            } catch (e) {
+                console.warn('[JE] renderServiceStatusDashboard threw; dashboard may be stale:', e);
+            }
+            try {
+                renderOptionalPluginsDashboard();
+            } catch (e) {
+                console.warn('[JE] renderOptionalPluginsDashboard threw:', e);
+            }
+            try {
+                renderFeaturesDashboard();
+            } catch (e) {
+                console.warn('[JE] renderFeaturesDashboard threw:', e);
+            }
+            try {
+                // Re-sync banner parent gating. loadConfig sets .checked
+                // programmatically, which DOESN'T fire the change event our
+                // banner listener uses — so we need an explicit refresh here.
+                if (typeof syncAllBannerParents === 'function') syncAllBannerParents();
+            } catch (e) {
+                console.warn('[JE] syncAllBannerParents threw:', e);
+            }
+            try {
+                // Don't auto-expand when triggered by a bulk dep sync —
+                // that would fire `open = true` on every tick the parent
+                // is checked, which is noisy. Real off→on transitions
+                // go through the dedicated change listener above.
+                applyGatedHelp(false);
+            } catch (e) {
+                console.warn('[JE] applyGatedHelp threw; gated help may be stale:', e);
+            }
         }
+
+        /**
+         * Reads `.value` from a selector, returning '' if the element is missing.
+         * Logs once per missing selector so DOM/JS mismatches surface in devtools
+         * instead of throwing silently through a querySelector chain.
+         * @param {string} sel - CSS selector
+         * @returns {string} Trimmed value, or '' if element not found
+         */
+        var _jeMissingSelectorsWarned = Object.create(null);
+        function readFieldValue(sel) {
+            var el = document.querySelector(sel);
+            if (!el) {
+                if (!_jeMissingSelectorsWarned[sel]) {
+                    _jeMissingSelectorsWarned[sel] = true;
+                    console.warn('[JE] status dashboard: selector "' + sel + '" not found');
+                }
+                return '';
+            }
+            return (el.value || '').trim();
+        }
+
+        /**
+         * Counts configured arr instance cards for a given type (sonarr|radarr).
+         * An instance is "configured" when both URL and API key are non-empty.
+         * Returns -1 (not 0) if the instance list container is missing, so callers
+         * can distinguish "user configured zero" from "DOM not ready / mismatched."
+         * @param {string} type - 'sonarr' or 'radarr'
+         * @returns {number} Count of fully-configured instances, or -1 if list missing
+         */
+        var _jeMissingListWarned = Object.create(null);
+        function countArrInstances(type) {
+            var listId = type === 'sonarr' ? 'sonarrInstancesList' : 'radarrInstancesList';
+            var list = document.getElementById(listId);
+            if (!list) {
+                if (!_jeMissingListWarned[listId]) {
+                    _jeMissingListWarned[listId] = true;
+                    console.warn('[JE] status dashboard: #' + listId + ' not found');
+                }
+                return -1;
+            }
+            var cards = list.querySelectorAll('.arr-instance-card');
+            var count = 0;
+            for (var i = 0; i < cards.length; i++) {
+                var url = cards[i].querySelector('.arr-instance-url');
+                var key = cards[i].querySelector('.arr-instance-apikey');
+                if (url && url.value.trim() && key && key.value.trim()) count++;
+            }
+            return count;
+        }
+
+        /**
+         * Merged Service Status renderer.
+         *
+         * Replaces the legacy status-card grid + Integration Health checklist
+         * with a single card list that sources:
+         *   - config state from the live form (key/URL/API-key presence, *arr
+         *     instance counts, Seerr URL list),
+         *   - test-result state from the connection-test cache (so a green
+         *     "connected" or red "failed" card reflects the latest probe).
+         *
+         * Card states (drive the left-border accent and icon):
+         *   - 'ok'      green    — configured; latest test passed (or no test
+         *                           run yet but no negative signal)
+         *   - 'warn'    amber    — configured partially (e.g. Seerr URL but no
+         *                           API key) OR connection-test returned
+         *                           amber (reachable but not healthy)
+         *   - 'error'   red      — connection-test returned error
+         *   - 'pending' grey dot — enabled + complete config, no cached result
+         *   - 'off'     faded    — disabled / no config entered yet
+         *
+         * Each card is a <button> that jumps to the relevant settings tab.
+         */
+        function renderServiceStatusDashboard() {
+            var root = document.getElementById('je-service-dashboard');
+            if (!root) return;
+
+            var cards = [];
+            function pushCard(opts) { cards.push(opts); }
+
+            // TMDB — no dedicated test endpoint; presence-based state only.
+            var tmdbKey = readFieldValue('#TMDB_API_KEY');
+            pushCard({
+                id: 'tmdb',
+                name: 'TMDB',
+                tab: 'extras',
+                state: tmdbKey ? 'ok' : 'off',
+                detail: tmdbKey ? 'API key set' : 'No API key',
+                icon: 'vpn_key'
+            });
+
+            // Seerr
+            var seerrEnabled = document.getElementById('jellyseerrEnabled');
+            var seerrUrls = readFieldValue('#jellyseerrUrls');
+            var seerrKey = readFieldValue('#JellyseerrApiKey');
+            if (seerrEnabled && seerrEnabled.checked) {
+                if (seerrUrls && seerrKey) {
+                    var r = checklistRowState('seerr', 'Configured — not yet verified');
+                    var urlCount = seerrUrls.split(/\r?\n/).filter(function(u) { return u.trim(); }).length;
+                    pushCard({
+                        id: 'seerr', name: 'Seerr', tab: 'seerr', icon: 'bolt',
+                        state: r.state === 'amber' ? 'warn' : r.state === 'pending' ? 'pending' : r.state,
+                        detail: r.detail + (urlCount > 1 ? ' · ' + urlCount + ' URLs' : '')
+                    });
+                } else {
+                    pushCard({
+                        id: 'seerr', name: 'Seerr', tab: 'seerr', icon: 'bolt', state: 'warn',
+                        detail: !seerrUrls && !seerrKey ? 'Enabled but URL and API key missing'
+                            : !seerrUrls ? 'URL missing' : 'API key missing'
+                    });
+                }
+            } else if (seerrUrls || seerrKey) {
+                pushCard({
+                    id: 'seerr', name: 'Seerr', tab: 'seerr', icon: 'bolt', state: 'off',
+                    detail: 'Configured but integration disabled'
+                });
+            }
+
+            // Sonarr / Radarr — one card per instance, reusing test-cache keys
+            ['sonarr', 'radarr'].forEach(function(type) {
+                var list = document.getElementById(type + 'InstancesList');
+                if (!list) return;
+                var arrCards = list.querySelectorAll('.arr-instance-card');
+                arrCards.forEach(function(card) {
+                    var urlEl = card.querySelector('.arr-instance-url');
+                    var keyEl = card.querySelector('.arr-instance-apikey');
+                    var nameEl = card.querySelector('.arr-instance-name');
+                    if (!urlEl || !keyEl) return;
+                    var urlVal = (urlEl.value || '').trim();
+                    var keyVal = (keyEl.value || '').trim();
+                    if (!urlVal && !keyVal) return;
+                    var nameVal = (nameEl && nameEl.value ? nameEl.value.trim() : '')
+                                  || (type === 'sonarr' ? 'Sonarr' : 'Radarr');
+                    var cacheKey = type + ':' + _jeNormalizeArrUrl(urlVal);
+                    var icon = type === 'sonarr' ? 'tv' : 'movie';
+
+                    // Disabled instances (Enabled checkbox unchecked) render as
+                    // a grayed-out "Disabled" card regardless of test-cache
+                    // state — a stale red/green badge on a disabled entry is
+                    // misleading because the instance isn't being used.
+                    var enCb = card.querySelector('.arr-instance-enabled');
+                    var isDisabled = enCb && !enCb.checked;
+                    if (isDisabled) {
+                        pushCard({
+                            id: cacheKey, name: nameVal, tab: 'arr', icon: icon, state: 'off',
+                            detail: 'Disabled'
+                        });
+                        return;
+                    }
+
+                    if (!urlVal || !keyVal) {
+                        pushCard({
+                            id: cacheKey, name: nameVal, tab: 'arr', icon: icon, state: 'warn',
+                            detail: !urlVal ? 'URL missing' : 'API key missing'
+                        });
+                        return;
+                    }
+                    var r = checklistRowState(cacheKey, 'Configured — not yet verified');
+                    pushCard({
+                        id: cacheKey, name: nameVal, tab: 'arr', icon: icon,
+                        state: r.state === 'amber' ? 'warn' : r.state === 'pending' ? 'pending' : r.state,
+                        detail: r.detail
+                    });
+                });
+            });
+
+            // Bazarr — no test endpoint; URL presence is the best signal
+            var bazarrUrl = readFieldValue('#bazarrUrl');
+            var bazarrMappings = readFieldValue('#bazarrUrlMappings');
+            if (bazarrUrl || bazarrMappings) {
+                pushCard({
+                    id: 'bazarr', name: 'Bazarr', tab: 'arr', icon: 'subtitles',
+                    state: bazarrUrl ? 'ok' : 'warn',
+                    detail: bazarrUrl ? 'URL configured' : 'Only URL mappings set'
+                });
+            }
+
+            root.textContent = '';
+            if (cards.length === 0) {
+                var empty = document.createElement('div');
+                empty.className = 'je-checklist-empty';
+                empty.textContent = 'Configure TMDB, Seerr, or an *arr instance to see its status here.';
+                root.appendChild(empty);
+                return;
+            }
+
+            // Order: warn/error first, then pending, then ok, then off (faded)
+            var ord = { error: 0, warn: 1, pending: 2, ok: 3, off: 4 };
+            cards.sort(function(a, b) { return (ord[a.state] || 99) - (ord[b.state] || 99); });
+
+            cards.forEach(function(c) {
+                var btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'je-service-card je-state-' + c.state;
+                btn.setAttribute('data-target', c.tab);
+                btn.setAttribute('data-status-id', c.id);
+                var iconEl = document.createElement('i');
+                iconEl.className = 'material-icons je-service-icon';
+                iconEl.setAttribute('aria-hidden', 'true');
+                iconEl.textContent = c.state === 'ok'      ? 'check_circle'
+                                   : c.state === 'warn'    ? 'warning'
+                                   : c.state === 'error'   ? 'error'
+                                   : c.state === 'pending' ? 'hourglass_empty'
+                                   : (c.icon || 'radio_button_unchecked');
+                btn.appendChild(iconEl);
+                var body = document.createElement('div');
+                body.className = 'je-service-body';
+                var nameEl = document.createElement('div');
+                nameEl.className = 'je-service-name';
+                nameEl.textContent = c.name;
+                body.appendChild(nameEl);
+                var detail = document.createElement('div');
+                detail.className = 'je-service-detail';
+                detail.textContent = c.detail;
+                body.appendChild(detail);
+                btn.appendChild(body);
+                btn.addEventListener('click', function() {
+                    var tabBtn = document.querySelector('.jellyfin-tab-button[data-tab="' + c.tab + '"]');
+                    if (tabBtn) tabBtn.click();
+                });
+                root.appendChild(btn);
+            });
+        }
+
+        // Back-compat: older code paths still call these by name. Delegate both
+        // to the unified renderer instead of maintaining dead duplicates.
+        function updateStatusDashboard() { renderServiceStatusDashboard(); }
 
         /**
          * Shows clear-client-cache controls only when server-side tag cache is disabled.
@@ -3917,6 +5706,31 @@
         ['#jellyseerrUrls', '#JellyseerrApiKey'].forEach(function(sel) {
             document.querySelector(sel).addEventListener('input', debouncedUpdateDeps);
         });
+
+        // Drop persisted "Last tested <date>" entries when the inputs that produced
+        // those tests change — otherwise an admin who rotated their TMDB API key or
+        // changed Seerr URLs would keep seeing a green checkmark from the previous
+        // credentials. The next test (or page render) re-establishes the row.
+        function _wireInvalidate(sel, key) {
+            var el = document.querySelector(sel);
+            if (!el) return;
+            var lastValue = el.value;
+            // Use 'change' (fires on blur/commit) rather than 'input' (fires per
+            // keystroke). Input-per-keystroke would invalidate + rebuild the
+            // service-status grid 30+ times during a TMDB key rotation, causing
+            // visible lag on slower machines. Change-on-commit gets the same
+            // correctness outcome without the churn.
+            el.addEventListener('change', function() {
+                if (el.value !== lastValue) {
+                    invalidatePersistedTest(key);
+                    lastValue = el.value;
+                }
+            });
+        }
+        _wireInvalidate('#TMDB_API_KEY',         'tmdb');
+        _wireInvalidate('#jellyseerr_TMDB_API_KEY', 'tmdb');
+        _wireInvalidate('#jellyseerrUrls',       'seerr');
+        _wireInvalidate('#JellyseerrApiKey',     'seerr');
 
         // Parent checkbox change listeners
         var parentIds = {};
@@ -3962,11 +5776,13 @@
                 return;
             }
 
+            var _testToken = (typeof beginConnectionTest === 'function') ? beginConnectionTest() : undefined;
             btn.disabled = true;
             indicator.textContent = 'sync';
             indicator.className = 'material-icons status-check';
-            indicator.style.color = '#00a4dc';
+            indicator.style.color = 'var(--primary-accent-color, #00a4dc)';
 
+            var arrCacheKey = type + ':' + _jeNormalizeArrUrl(urlVal);
             try {
                 var endpoint = type === 'sonarr' ? 'sonarr' : 'radarr';
                 var validationUrl = ApiClient.getUrl('/JellyfinEnhanced/arr/validate/' + endpoint, { url: urlVal });
@@ -3975,14 +5791,21 @@
                 indicator.textContent = 'check_circle';
                 indicator.style.color = '#52b54b';
                 indicator.classList.remove('status-check');
-                Dashboard.alert({ title: 'Success', message: 'Successfully connected to ' + nameVal + '!' });
+                try { setConnectionTestResult(arrCacheKey, 'ok', 'Connected', _testToken); } catch (err) { /* cache is best-effort */ }
+                jeTestAlert({ title: 'Success', message: 'Successfully connected to ' + nameVal + '!' });
             } catch (e) {
                 indicator.classList.remove('status-check');
                 indicator.textContent = 'error';
                 indicator.style.color = '#dc3545';
 
                 var msg = connectionErrorMessage(e, nameVal, urlVal);
-                Dashboard.alert({ title: 'Connection Failed', message: msg });
+                try {
+                    var shortArrDetail = e && e.status === 401 ? 'API key rejected'
+                        : e && (e.status === 500 || e.status === 0 || !e.status) ? 'Unreachable'
+                        : 'Error ' + (e && e.status ? e.status : '?');
+                    setConnectionTestResult(arrCacheKey, 'error', shortArrDetail, _testToken);
+                } catch (err) { /* cache is best-effort */ }
+                jeTestAlert({ title: 'Connection Failed', message: msg });
             } finally {
                 btn.disabled = false;
             }
@@ -4004,38 +5827,7 @@
         }
 
         /**
-         * Probes a URL via the backend to identify what service is running at that address.
-         * @param {string} url - The URL to probe
-         * @returns {Promise<Object>} Result with reachable and service properties
-         */
-        async function identifyUrl(url) {
-            try {
-                var apiUrl = ApiClient.getUrl('/JellyfinEnhanced/arr/identify-url', { url: url });
-                return await ApiClient.ajax({ type: 'GET', url: apiUrl, dataType: 'json' });
-            } catch (e) {
-                return { reachable: false, service: 'unknown' };
-            }
-        }
-
-        /**
-         * Client-side fallback to check URL reachability via a no-cors fetch with timeout.
-         * @param {string} url - The URL to check
-         * @returns {Promise<boolean>} True if the URL responds within 5 seconds
-         */
-        async function isReachableFromBrowser(url) {
-            try {
-                var controller = new AbortController();
-                var timer = setTimeout(function() { controller.abort(); }, 5000);
-                await fetch(url, { mode: 'no-cors', signal: controller.signal });
-                clearTimeout(timer);
-                return true;
-            } catch (e) {
-                return false;
-            }
-        }
-
-        /**
-         * Validates URL mapping entries by probing each URL and checking for mismatches.
+         * Validates URL mapping entries for syntactic correctness.
          * @param {Array<Object>} mappingDefs - Array of mapping definitions with inputId and expectedService
          * @param {string} btnId - DOM id of the validate button
          * @param {string} resultDivId - DOM id of the results container
@@ -4043,12 +5835,23 @@
         async function validateMappingSet(mappingDefs, btnId, resultDivId) {
             var btn = document.getElementById(btnId);
             var resultDiv = document.getElementById(resultDivId);
+            // Update button label safely whether the markup wraps the text
+            // in a <span> (legacy emby-button pattern) or has bare text content.
+            // The previous implementation assumed a <span> always existed and
+            // threw `Cannot set properties of null` when it didn't, which silently
+            // killed the rest of validation (button stayed disabled, result div
+            // stayed empty, no error surfaced to the admin).
+            function setBtnLabel(text) {
+                var span = btn.querySelector('span');
+                if (span) span.textContent = text;
+                else btn.textContent = text;
+            }
             btn.disabled = true;
-            btn.querySelector('span').textContent = 'Validating...';
+            setBtnLabel('Validating...');
             resultDiv.textContent = '';
             resultDiv.style.display = 'block';
-            resultDiv.style.backgroundColor = 'rgba(0, 164, 220, 0.1)';
-            resultDiv.style.borderLeft = '4px solid #00a4dc';
+            resultDiv.style.backgroundColor = 'color-mix(in srgb, var(--primary-accent-color, #00a4dc) 10%, transparent)';
+            resultDiv.style.borderLeft = '4px solid var(--primary-accent-color, #00a4dc)';
             resultDiv.textContent = 'Testing URLs...';
 
             // Collect all pairs with basic format validation first
@@ -4091,140 +5894,53 @@
                 resultDiv.style.borderLeft = '4px solid #dc3545';
                 formatIssues.forEach(function(i) { addIssue(resultDiv, i); });
                 btn.disabled = false;
-                btn.querySelector('span').textContent = 'Validate Mappings';
+                setBtnLabel('Validate Mappings');
                 return;
             }
 
             if (pairs.length === 0 && formatIssues.length === 0) {
                 resultDiv.style.display = 'none';
                 btn.disabled = false;
-                btn.querySelector('span').textContent = 'Validate Mappings';
+                setBtnLabel('Validate Mappings');
                 return;
             }
 
-            // Identify all unique URLs
-            var uniqueUrls = {};
-            pairs.forEach(function(p) {
-                uniqueUrls[p.left.replace(/\/+$/, '')] = null;
-                uniqueUrls[p.right.replace(/\/+$/, '')] = null;
-            });
-
-            // Also probe configured service URLs so we can cross-reference client-only mappings
-            var serviceUrlIds = { 'Bazarr': 'bazarrUrl', 'Seerr': 'jellyseerrUrls' };
-            pairs.forEach(function(p) {
-                var urlId = serviceUrlIds[p.service];
-                if (!urlId) return;
-                var configLines = (document.getElementById(urlId)?.value || '').split('\n');
-                configLines.forEach(function(line) {
-                    var configUrl = line.trim().replace(/\/+$/, '');
-                    if (configUrl && !uniqueUrls.hasOwnProperty(configUrl)) {
-                        uniqueUrls[configUrl] = null;
-                    }
-                });
-            });
-
-            var urlKeys = Object.keys(uniqueUrls);
-            var results = await Promise.all(urlKeys.map(function(u) { return identifyUrl(u); }));
-            urlKeys.forEach(function(u, i) { uniqueUrls[u] = results[i]; });
-
-            // For unreachable URLs, try client-side probe as fallback
-            // (server may not reach localhost/VPN URLs that the browser can)
-            var unreachable = urlKeys.filter(function(u) { return !uniqueUrls[u].reachable; });
-            if (unreachable.length > 0) {
-                var clientResults = await Promise.all(unreachable.map(function(u) { return isReachableFromBrowser(u); }));
-                unreachable.forEach(function(u, i) {
-                    if (clientResults[i]) {
-                        uniqueUrls[u] = { reachable: true, service: 'unknown', clientOnly: true };
-                    }
-                });
-            }
-
-            // Analyze each pair
+            // Syntax-only validation: ensure each URL parses as a valid URL
+            // and that the two sides of a mapping aren't identical. We used to
+            // probe each URL server-side (and fall back to a browser probe) and
+            // identify whether the far end was actually Sonarr/Radarr/Jellyfin/…
+            // but mappings are only used to rewrite link hrefs, so "is this
+            // URL parseable and distinct from its pair" is the only thing that
+            // actually needs to hold. Probing breaks for anyone behind an auth
+            // proxy (Authentik, Authelia, Cloudflare Access, …) because the
+            // backend never reaches the service to identify it.
             var issues = formatIssues.slice();
             var warnings = [];
             var good = 0;
 
             pairs.forEach(function(p) {
-                var leftInfo = uniqueUrls[p.left.replace(/\/+$/, '')] || { reachable: false, service: 'unknown' };
-                var rightInfo = uniqueUrls[p.right.replace(/\/+$/, '')] || { reachable: false, service: 'unknown' };
+                var leftTrim  = p.left.replace(/\/+$/, '');
+                var rightTrim = p.right.replace(/\/+$/, '');
 
-                // Both sides must be reachable from server or browser
-                if (!leftInfo.reachable) {
-                    issues.push(p.label + ': Left URL (' + p.left + ') is unreachable from both the server and your browser. Check for typos.');
-                    return;
-                }
-                if (!rightInfo.reachable) {
-                    issues.push(p.label + ': Right URL (' + p.right + ') is unreachable. Check for typos or that ' + p.service + ' is running.');
-                    return;
+                function urlOk(u) {
+                    try { var parsed = new URL(u); return !!parsed.host; }
+                    catch (e) { return false; }
                 }
 
-                var leftLower = p.left.toLowerCase().replace(/\/+$/, '');
-                var rightLower = p.right.toLowerCase().replace(/\/+$/, '');
-                if (leftLower === rightLower) {
+                if (!urlOk(p.left)) {
+                    issues.push(p.label + ': Left side (' + p.left + ') is not a valid URL.');
+                    return;
+                }
+                if (!urlOk(p.right)) {
+                    issues.push(p.label + ': Right side (' + p.right + ') is not a valid URL.');
+                    return;
+                }
+                if (leftTrim.toLowerCase() === rightTrim.toLowerCase()) {
                     issues.push(p.label + ': Both sides are the same URL. Left should be Jellyfin, right should be ' + p.service + '.');
                     return;
                 }
 
-                // Check if left side is actually an arr service (detectable = definitely wrong)
-                var leftIsArr = leftInfo.reachable && (leftInfo.service === 'Sonarr' || leftInfo.service === 'Radarr' || leftInfo.service === 'arr' || leftInfo.service === 'Bazarr' || leftInfo.service === 'Seerr');
-                var rightIsJellyfin = (rightInfo.service === 'Jellyfin');
-
-                if (leftIsArr) {
-                    var detected = leftInfo.service === 'arr' ? 'an *arr service' : leftInfo.service;
-                    if (rightIsJellyfin) {
-                        issues.push(p.label + ': URLs are reversed. Left side is ' + detected + ' and right side is Jellyfin. Swap them: Jellyfin URL goes on the left, ' + p.service + ' URL on the right.');
-                    } else {
-                        issues.push(p.label + ': Left side (' + p.left + ') is running ' + detected + ', not Jellyfin. Left should be your Jellyfin URL.');
-                    }
-                    return;
-                }
-
-                if (rightIsJellyfin) {
-                    issues.push(p.label + ': Right side (' + p.right + ') is running Jellyfin, not ' + p.service + '. Right should be the ' + p.service + ' URL.');
-                    return;
-                }
-
-                // Check service mismatch (e.g., Sonarr mapping pointing to Radarr)
-                // p.service may be an instance name like "Sonarr Main" or "Radarr 4K",
-                // so check if the detected service is contained in the instance name
-                var serviceMatchesInstance = rightInfo.service === p.service
-                    || p.service.toLowerCase().indexOf(rightInfo.service.toLowerCase()) !== -1
-                    || rightInfo.service === 'arr';
-                if (rightInfo.service !== 'unknown' && !serviceMatchesInstance) {
-                    issues.push(p.label + ': Right side (' + p.right + ') is running ' + rightInfo.service + ', but this is the ' + p.service + ' mapping section.');
-                    return;
-                }
-
-                // Right side confirmed as correct service?
-                var rightConfirmed = serviceMatchesInstance;
-
-                // If right side is only browser-reachable (server can't reach localhost etc.),
-                // check if the configured service URL confirms the service identity
-                if (!rightConfirmed && rightInfo.clientOnly) {
-                    var configUrlId = serviceUrlIds[p.service];
-                    if (configUrlId) {
-                        var configLines = (document.getElementById(configUrlId)?.value || '').split('\n');
-                        var mappingPort = (p.right.match(/:(\d+)/) || [])[1] || '';
-                        for (var ci = 0; ci < configLines.length && !rightConfirmed; ci++) {
-                            var configUrl = configLines[ci].trim().replace(/\/+$/, '');
-                            if (!configUrl) continue;
-                            var configInfo = uniqueUrls[configUrl];
-                            if (configInfo && (configInfo.service === p.service || (configInfo.service === 'arr' && p.service !== 'Bazarr'))) {
-                                var configPort = (configUrl.match(/:(\d+)/) || [])[1] || '';
-                                if (mappingPort && configPort && mappingPort === configPort) {
-                                    rightConfirmed = true;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (rightConfirmed) {
-                    good++;
-                } else {
-                    // Reachable but unknown service — could be anything (SABnzbd, nginx, etc.)
-                    warnings.push(p.label + ': Right side (' + p.right + ') is reachable but JE could not verify it is ' + p.service + '. This may still work correctly — JE just cannot confirm the service automatically.');
-                }
+                good++;
             });
 
             // Display results
@@ -4254,81 +5970,134 @@
             }
 
             btn.disabled = false;
-            btn.querySelector('span').textContent = 'Validate Mappings';
+            setBtnLabel('Validate Mappings');
         }
 
-        document.getElementById('validateArrMappingsBtn').addEventListener('click', function() {
-            // Collect all instance URL mappings + Bazarr mappings
+        // Per-service mapping validation helpers. Each service's Validate button
+        // collects only its own instances' mappings (plus Bazarr's single field),
+        // feeds them through validateMappingSet, and cleans up any temp textareas
+        // it creates. Split from the old "validate everything" button so results
+        // land next to the service being tested.
+        function _jeValidateInstanceMappings(type, btnId, resultId, displayName) {
             var mappingDefs = [];
             var createdTempIds = [];
+            // Wipe orphan temp textareas from a prior run (lets us also accept
+            // those leftover from a previous failed validation with the same
+            // prefix).
+            document.querySelectorAll('textarea[data-arr-validate-temp-' + type + '="true"]').forEach(function(el) { el.remove(); });
 
-            // Wipe any temp textareas left over from a previous validate run so we never
-            // accumulate orphans when a card that previously had mappings now has none.
-            document.querySelectorAll('textarea[data-arr-validate-temp="true"]').forEach(function(el) { el.remove(); });
-
-            function addTempTextarea(value, prefix, idx, serviceName) {
-                var tempId = prefix + '-' + idx;
-                var temp = document.createElement('textarea');
-                temp.id = tempId;
-                temp.value = value;
-                temp.style.display = 'none';
-                temp.setAttribute('data-arr-validate-temp', 'true');
-                document.body.appendChild(temp);
-                createdTempIds.push(tempId);
-                mappingDefs.push({ id: tempId, service: serviceName });
-            }
-
-            // Per-instance URL mappings from cards
-            document.querySelectorAll('#sonarrInstancesList .arr-instance-card').forEach(function(card, idx) {
-                var name = card.querySelector('.arr-instance-name').value.trim() || ('Sonarr ' + (idx + 1));
+            var listId = type + 'InstancesList';
+            document.querySelectorAll('#' + listId + ' .arr-instance-card').forEach(function(card, idx) {
+                var name = card.querySelector('.arr-instance-name').value.trim() || (displayName + ' ' + (idx + 1));
                 var textarea = card.querySelector('.arr-instance-urlmappings');
                 if (textarea && textarea.value.trim()) {
-                    addTempTextarea(textarea.value, 'arr-validate-sonarr', idx, name);
+                    var tempId = 'arr-validate-' + type + '-' + idx;
+                    var temp = document.createElement('textarea');
+                    temp.id = tempId;
+                    temp.value = textarea.value;
+                    temp.style.display = 'none';
+                    temp.setAttribute('data-arr-validate-temp-' + type, 'true');
+                    document.body.appendChild(temp);
+                    createdTempIds.push(tempId);
+                    mappingDefs.push({ id: tempId, service: name });
                 }
             });
-
-            document.querySelectorAll('#radarrInstancesList .arr-instance-card').forEach(function(card, idx) {
-                var name = card.querySelector('.arr-instance-name').value.trim() || ('Radarr ' + (idx + 1));
-                var textarea = card.querySelector('.arr-instance-urlmappings');
-                if (textarea && textarea.value.trim()) {
-                    addTempTextarea(textarea.value, 'arr-validate-radarr', idx, name);
-                }
-            });
-
-            // Bazarr mappings
-            if (document.getElementById('bazarrUrlMappings').value.trim()) {
-                mappingDefs.push({ id: 'bazarrUrlMappings', service: 'Bazarr' });
-            }
 
             if (mappingDefs.length === 0) {
-                Dashboard.alert({ title: 'No Mappings', message: 'No URL mappings configured to validate. Add mappings in the instance cards or Bazarr section.' });
+                Dashboard.alert({ title: 'No Mappings', message: 'No URL mappings configured for ' + displayName + '. Expand an instance card and fill in the URL Mappings field to validate.' });
                 return;
             }
-
-            // validateMappingSet is async and reads our temp textareas while it runs, so we
-            // can't remove them synchronously here. `.finally(cleanup)` removes ours after the
-            // promise settles, and the "wipe at entry" above handles any leftovers that linger
-            // if a previous run errored between commit and cleanup. `.finally` (rather than
-            // `.then(cleanup, cleanup)`) lets any rejection propagate so the browser's
-            // unhandled-rejection reporting still catches real bugs in the validator.
             var cleanup = function() {
                 createdTempIds.forEach(function(id) {
                     var el = document.getElementById(id);
                     if (el) el.remove();
                 });
             };
-            validateMappingSet(
-                mappingDefs,
-                'validateArrMappingsBtn', 'arrMappingsValidationResult'
-            ).finally(cleanup);
-        });
+            validateMappingSet(mappingDefs, btnId, resultId)
+                .finally(cleanup)
+                .catch(function(err) {
+                    // Without an explicit .catch, a thrown rejection (missing btn
+                    // node, pre-await TypeError, failed Promise.all inside the
+                    // validator) would leave the Validate button stuck on its
+                    // disabled/"Validating..." state and the admin with no visible
+                    // signal beyond an Uncaught (in promise) message in devtools.
+                    console.error('[JE] mapping validation crashed:', err);
+                    var btn = document.getElementById(btnId);
+                    if (btn) {
+                        btn.disabled = false;
+                        var span = btn.querySelector('span');
+                        if (span) span.textContent = 'Validate Mappings';
+                        else btn.textContent = 'Validate Mappings';
+                    }
+                    try {
+                        Dashboard.alert({ title: 'Validation error', message: 'Mapping validation crashed unexpectedly — check the browser console for details.' });
+                    } catch (alertErr) {
+                        console.warn('[JE] Dashboard.alert threw during validation-error notify:', alertErr);
+                        try { window.alert('Validation error: ' + ((err && err.message) || err)); } catch (_) { /* last-resort notify — if alert() itself throws we've given up */ }
+                    }
+                });
+        }
 
-        document.getElementById('validateSeerrMappingsBtn').addEventListener('click', function() {
-            validateMappingSet(
-                [{ id: 'jellyseerrUrlMappings', service: 'Seerr' }],
-                'validateSeerrMappingsBtn', 'seerrMappingsValidationResult'
-            );
-        });
+        var validateSonarrMappingsBtn = document.getElementById('validateSonarrMappingsBtn');
+        if (validateSonarrMappingsBtn) {
+            validateSonarrMappingsBtn.addEventListener('click', function() {
+                _jeValidateInstanceMappings('sonarr', 'validateSonarrMappingsBtn', 'sonarrMappingsValidationResult', 'Sonarr');
+            });
+        }
+        var validateRadarrMappingsBtn = document.getElementById('validateRadarrMappingsBtn');
+        if (validateRadarrMappingsBtn) {
+            validateRadarrMappingsBtn.addEventListener('click', function() {
+                _jeValidateInstanceMappings('radarr', 'validateRadarrMappingsBtn', 'radarrMappingsValidationResult', 'Radarr');
+            });
+        }
+        // Safety-net wrapper used by the three mapping-validate buttons.
+        // Mirrors the .catch + button-reset handler inside _jeValidateInstanceMappings
+        // so Bazarr/Seerr direct callers get the same treatment. Without this,
+        // a rejected validateMappingSet() promise would leave the button stuck on
+        // "Validating..." with only an Uncaught (in promise) in devtools.
+        function _jeRunMappingValidation(mappingDefs, btnId, resultId) {
+            validateMappingSet(mappingDefs, btnId, resultId).catch(function(err) {
+                console.error('[JE] mapping validation crashed:', err);
+                var b = document.getElementById(btnId);
+                if (b) {
+                    b.disabled = false;
+                    var span = b.querySelector('span');
+                    if (span) span.textContent = 'Validate Mappings';
+                    else b.textContent = 'Validate Mappings';
+                }
+                try {
+                    Dashboard.alert({ title: 'Validation error', message: 'Mapping validation crashed unexpectedly — check the browser console for details.' });
+                } catch (alertErr) {
+                    console.warn('[JE] Dashboard.alert threw during validation-error notify:', alertErr);
+                    try { window.alert('Validation error: ' + ((err && err.message) || err)); } catch (_) { /* last-resort notify — if alert() itself throws we've given up */ }
+                }
+            });
+        }
+
+        var validateBazarrMappingsBtn = document.getElementById('validateBazarrMappingsBtn');
+        if (validateBazarrMappingsBtn) {
+            validateBazarrMappingsBtn.addEventListener('click', function() {
+                var mappings = document.getElementById('bazarrUrlMappings');
+                if (!mappings || !mappings.value.trim()) {
+                    Dashboard.alert({ title: 'No Mappings', message: 'No Bazarr URL mappings configured. Fill in the Bazarr URL Mappings field above to validate.' });
+                    return;
+                }
+                _jeRunMappingValidation(
+                    [{ id: 'bazarrUrlMappings', service: 'Bazarr' }],
+                    'validateBazarrMappingsBtn', 'bazarrMappingsValidationResult'
+                );
+            });
+        }
+
+        var validateSeerrMappingsBtn = document.getElementById('validateSeerrMappingsBtn');
+        if (validateSeerrMappingsBtn) {
+            validateSeerrMappingsBtn.addEventListener('click', function() {
+                _jeRunMappingValidation(
+                    [{ id: 'jellyseerrUrlMappings', service: 'Seerr' }],
+                    'validateSeerrMappingsBtn', 'seerrMappingsValidationResult'
+                );
+            });
+        }
 
         clearTagsCacheBtn.addEventListener('click', async () => {
             if (confirm("Clear all client caches?\n\nThis will force all clients to clear their quality and genre tag caches on next page load.")) {
@@ -4353,6 +6122,192 @@
             }
         });
         testJellyseerrBtn.addEventListener('click', testJellyseerrConnection);
+
+        /**
+         * Quick Action: re-test every external-service connection by proxying
+         * clicks to the existing per-service test buttons. Preserves the per-
+         * button UX (spinners, toasts, status-card updates) without duplicating
+         * logic. Does NOT fabricate a cache — Phase 4 layers a real test cache
+         * on top.
+         *
+         * Services invoked:
+         *   - TMDB: one `.testTmdbBtn` click (multiple copies exist across tabs
+         *     but any one test updates the shared status card)
+         *   - Seerr: `#testJellyseerrBtn` when Seerr is enabled + URL + key set
+         *   - Sonarr / Radarr: every `.arr-instance-test` inside the instance
+         *     lists that has a URL + API key populated
+         *
+         * Skipping an unconfigured service is intentional — clicking a test
+         * button with empty fields would pop a Dashboard.alert per service,
+         * which is noisy for a "one-shot retest" action.
+         */
+        // Client-side throttle + in-flight lock for the Re-test-all batch.
+        // The button is disabled for the full cooldown window so rapid
+        // clicks can't fire ~8 parallel external-API tests per click. This
+        // is NOT a security boundary — a determined user could still spam
+        // via devtools — it's a guardrail against well-intentioned double-
+        // clicks and page-reload retries.
+        // Minimum time the Re-test-all button stays disabled even if every
+        // test finishes instantly. Acts as the rate-limit floor so rapid
+        // re-clicks can't fire dozens of external API tests per second.
+        var RETEST_ALL_MIN_COOLDOWN_MS = 4 * 1000;
+        // Hard upper bound for the polling loop. If a test still hasn't
+        // resolved after this long, we force-release anyway so the UI
+        // doesn't sit "Retesting…" forever on a hung connection.
+        var RETEST_ALL_MAX_WAIT_MS = 25 * 1000;
+        var _jeRetestAllCooldownUntil = 0;
+        var _jeRetestAllReenableTimer = null;
+        var _jeRetestAllPollTimer = null;
+
+        function _setRetestAllButtonLabel(btn, text) {
+            if (!btn) return;
+            var labelEl = btn.querySelector('.je-quick-action-title');
+            if (labelEl) labelEl.textContent = text;
+        }
+
+        var retestAllConnectionsBtn = document.getElementById('retestAllConnectionsBtn');
+        if (retestAllConnectionsBtn) {
+            var _retestAllOriginalLabel = retestAllConnectionsBtn.querySelector('.je-quick-action-title');
+            _retestAllOriginalLabel = _retestAllOriginalLabel ? _retestAllOriginalLabel.textContent : 'Re-test all service connections';
+
+            retestAllConnectionsBtn.addEventListener('click', function() {
+                // Throttle: block rapid re-clicks within the cooldown window.
+                var now = Date.now();
+                if (now < _jeRetestAllCooldownUntil) {
+                    var remainSec = Math.ceil((_jeRetestAllCooldownUntil - now) / 1000);
+                    try {
+                        Dashboard.alert({
+                            title: 'Please wait',
+                            message: 'Re-test is rate-limited. Try again in ' + remainSec + ' s.'
+                        });
+                    } catch (e) { /* ignore */ }
+                    return;
+                }
+
+                // Invalidate the cache up front so every checklist row flips
+                // to "pending" immediately; the individual test handlers will
+                // repopulate it as they finish.
+                try { clearConnectionTestCache(); } catch (e) { /* renderChecklist logs */ }
+
+                // Suppress per-test Dashboard.alert dialogs for the duration
+                // of this batch — per-service indicators + the Integration
+                // Health rows already communicate results.
+                _jeSuppressTestAlerts = true;
+                _jeRetestAllCooldownUntil = now + RETEST_ALL_MIN_COOLDOWN_MS;
+                retestAllConnectionsBtn.disabled = true;
+                _setRetestAllButtonLabel(retestAllConnectionsBtn, 'Retesting…');
+
+                var tested = 0;
+
+                // TMDB — one click is enough; pages share the same backing key
+                var tmdbBtn = document.querySelector('.testTmdbBtn');
+                if (tmdbBtn && !tmdbBtn.disabled) { tmdbBtn.click(); tested++; }
+
+                // Seerr — only if enabled with a URL + key (otherwise button
+                // would show a "missing info" toast, which is noisy for a
+                // batch re-test action).
+                var seerrEnabled = document.querySelector('#jellyseerrEnabled');
+                var seerrUrls = document.querySelector('#jellyseerrUrls');
+                var seerrKey = document.querySelector('#JellyseerrApiKey');
+                if (seerrEnabled && seerrEnabled.checked
+                    && seerrUrls && seerrUrls.value.trim()
+                    && seerrKey && seerrKey.value.trim()
+                    && testJellyseerrBtn && !testJellyseerrBtn.disabled) {
+                    testJellyseerrBtn.click();
+                    tested++;
+                }
+
+                // Sonarr / Radarr — per-instance tests. The per-instance test
+                // function itself guards against empty URL/API-key, so we
+                // don't need to re-check here; we just skip already-disabled
+                // buttons (mid-flight tests).
+                var arrBtns = document.querySelectorAll('.arr-instance-test');
+                arrBtns.forEach(function(btn) {
+                    var card = btn.closest('.arr-instance-card');
+                    if (!card) return;
+                    var urlEl = card.querySelector('.arr-instance-url');
+                    var keyEl = card.querySelector('.arr-instance-apikey');
+                    if (!urlEl || !keyEl) return;
+                    if (!urlEl.value.trim() || !keyEl.value.trim()) return;
+                    if (btn.disabled) return;
+                    btn.click();
+                    tested++;
+                });
+
+                // Always refresh the dashboard dots so the user sees feedback
+                // even when no service was re-tested.
+                try { updateStatusDashboard(); } catch (e) { /* logged inside */ }
+
+                if (tested === 0) {
+                    _jeSuppressTestAlerts = false;
+                    retestAllConnectionsBtn.disabled = false;
+                    _setRetestAllButtonLabel(retestAllConnectionsBtn, _retestAllOriginalLabel);
+                    _jeRetestAllCooldownUntil = 0; // reset cooldown — nothing fired
+                    try {
+                        Dashboard.alert({
+                            title: 'Nothing to re-test',
+                            message: 'Enable and configure at least one service (TMDB, Seerr, Sonarr, or Radarr) before running a re-test.'
+                        });
+                    } catch (e) { /* ignore */ }
+                    return;
+                }
+
+                // The individual test functions don't return promises
+                // (they're event handlers fired via .click()), so we poll
+                // the DOM for the "in-flight" signal each test sets on
+                // start: the `.status-check` class on its status indicator.
+                // When no indicators still carry that class, every test
+                // has resolved — release the button immediately. Falls
+                // back to a hard max-wait so a hung request doesn't leave
+                // the button stuck on "Retesting…".
+                clearTimeout(_jeRetestAllReenableTimer);
+                clearInterval(_jeRetestAllPollTimer);
+                var batchStartedAt = Date.now();
+                function releaseRetestBatch() {
+                    clearInterval(_jeRetestAllPollTimer);
+                    clearTimeout(_jeRetestAllReenableTimer);
+                    _jeSuppressTestAlerts = false;
+                    retestAllConnectionsBtn.disabled = false;
+                    _setRetestAllButtonLabel(retestAllConnectionsBtn, _retestAllOriginalLabel);
+                    try { renderChecklist(); } catch (e) { /* logged */ }
+                }
+                _jeRetestAllPollTimer = setInterval(function() {
+                    var elapsed = Date.now() - batchStartedAt;
+                    // `.status-check` is applied on test START and removed on
+                    // test RESOLVE (success or failure), so it's an accurate
+                    // "in-flight" signal for the three test functions.
+                    var inFlight = document.querySelectorAll('.status-check').length;
+                    // Release when BOTH:
+                    //  - no tests still in flight (UI has caught up), and
+                    //  - the min-cooldown floor has elapsed (rate limit).
+                    // The floor ensures a user who hits retest-all with zero
+                    // real tests configured still has the button disabled long
+                    // enough to prevent double-run, and covers the first-tick
+                    // race where indicators haven't swapped to 'sync' yet.
+                    if (inFlight === 0 && elapsed >= RETEST_ALL_MIN_COOLDOWN_MS) {
+                        releaseRetestBatch();
+                    } else if (elapsed >= RETEST_ALL_MAX_WAIT_MS) {
+                        console.warn('[JE] retest-all: giving up on ' + inFlight + ' in-flight test(s) after ' + elapsed + 'ms');
+                        releaseRetestBatch();
+                    }
+                }, 300);
+                // Hard-stop safety net in case setInterval is suspended
+                // (backgrounded tab, browser throttling, etc.).
+                _jeRetestAllReenableTimer = setTimeout(releaseRetestBatch, RETEST_ALL_MAX_WAIT_MS + 500);
+            });
+        }
+
+        /**
+         * Quick Action: proxy the "Clear client tag caches" button from the
+         * Display tab. Keeps the canonical clear-flow in one place while
+         * giving the action a home on Overview.
+         */
+        var clearTagCachesQuickBtn = document.getElementById('clearTagCachesQuickBtn');
+        if (clearTagCachesQuickBtn && clearTagsCacheBtn) {
+            clearTagCachesQuickBtn.addEventListener('click', function() {
+                clearTagsCacheBtn.click();
+            });
+        }
 
         /**
          * Updates the blocked users count badge in the collapsible summary.
@@ -4491,123 +6446,488 @@
             }
         });
 
-        // Permission Audit
-        document.getElementById('btnPermissionAudit').addEventListener('click', async () => {
-            const btn = document.getElementById('btnPermissionAudit');
-            const resultDiv = document.getElementById('permissionAuditResult');
-            btn.disabled = true;
-            btn.querySelector('span').textContent = 'Running…';
-            resultDiv.style.display = 'none';
-            resultDiv.innerHTML = '';
-
-            try {
-                const data = await ApiClient.ajax({
-                    type: 'GET',
-                    url: ApiClient.getUrl('/JellyfinEnhanced/jellyseerr/permission-audit'),
-                    dataType: 'json'
-                });
-
-                const withIssues  = data.filter(u => u.linked && u.issues && u.issues.length > 0);
-                const ok          = data.filter(u => u.linked && (!u.issues || u.issues.length === 0));
-                const unlinked    = data.filter(u => !u.linked);
-
-                const summaryEl = document.createElement('div');
-                summaryEl.className = 'je-audit-summary';
-                if (withIssues.length === 0 && unlinked.length === 0) {
-                    summaryEl.textContent = '✅ All ' + ok.length + ' linked user(s) have the required permissions.';
-                } else {
-                    const parts = [];
-                    if (withIssues.length) parts.push(withIssues.length + ' user(s) with permission gaps');
-                    if (unlinked.length)   parts.push(unlinked.length + ' not linked to Seerr');
-                    if (ok.length)         parts.push(ok.length + ' OK');
-                    summaryEl.textContent = parts.join(' · ');
-                }
-                resultDiv.appendChild(summaryEl);
-
-                if (withIssues.length > 0 || unlinked.length > 0) {
-                    const table = document.createElement('table');
-                    table.className = 'je-audit-table';
-                    table.innerHTML = '<thead><tr><th>User</th><th>Status</th><th>Issues</th></tr></thead>';
-                    const tbody = document.createElement('tbody');
-
-                    [...withIssues, ...unlinked].forEach(function(u) {
-                        const tr = document.createElement('tr');
-                        tr.className = 'je-audit-row-warn';
-
-                        const tdUser = document.createElement('td');
-                        tdUser.className = 'je-audit-username';
-                        tdUser.textContent = u.jellyfinUsername;
-
-                        const tdStatus = document.createElement('td');
-                        const statusSpan = document.createElement('span');
-                        statusSpan.className = u.linked ? 'je-audit-status-warn' : 'je-audit-status-unlinked';
-                        statusSpan.textContent = u.linked ? 'Permissions Missing' : 'Not linked';
-                        tdStatus.appendChild(statusSpan);
-
-                        const tdIssues = document.createElement('td');
-                        const ul = document.createElement('ul');
-                        ul.className = 'je-audit-issues';
-                        (u.issues || []).forEach(function(issue) {
-                            const li = document.createElement('li');
-                            li.textContent = issue;
-                            ul.appendChild(li);
-                        });
-                        tdIssues.appendChild(ul);
-
-                        tr.appendChild(tdUser);
-                        tr.appendChild(tdStatus);
-                        tr.appendChild(tdIssues);
-                        tbody.appendChild(tr);
+        // Permission Audit — admin scans every Jellyfin user for missing Seerr
+        // permissions required by the features the admin has currently enabled.
+        // GETs /JellyfinEnhanced/jellyseerr/permission-audit which returns
+        // [{ jellyfinUsername, linked, issues:[...] }]. We render a summary
+        // line + a table of users with gaps (warnings/unlinked first, then
+        // a collapsed "OK" group). Errors surface inline in the result div
+        // and are also logged to console.error so the admin can debug.
+        (function wirePermissionAudit() {
+            var btn = document.getElementById('btnPermissionAudit');
+            if (!btn) return;
+            // Resilient label setter (mirrors the validate-mapping fix): some
+            // emby-button markup wraps text in a <span>, some places it bare.
+            function setBtnLabel(text) {
+                var span = btn.querySelector('span');
+                if (span) span.textContent = text;
+                else btn.textContent = text;
+            }
+            btn.addEventListener('click', async function() {
+                var resultDiv = document.getElementById('permissionAuditResult');
+                btn.disabled = true;
+                setBtnLabel('Running…');
+                resultDiv.style.display = 'none';
+                resultDiv.innerHTML = '';
+                try {
+                    var data = await ApiClient.ajax({
+                        type: 'GET',
+                        url: ApiClient.getUrl('/JellyfinEnhanced/jellyseerr/permission-audit'),
+                        dataType: 'json'
                     });
+                    var withIssues = data.filter(function(u) { return u.linked && u.issues && u.issues.length > 0; });
+                    var ok         = data.filter(function(u) { return u.linked && (!u.issues || u.issues.length === 0); });
+                    var unlinked   = data.filter(function(u) { return !u.linked; });
 
-                    if (ok.length > 0) {
-                        const trOk = document.createElement('tr');
-                        const tdOk = document.createElement('td');
-                        tdOk.colSpan = 3;
-                        tdOk.style.paddingTop = '0.5em';
-                        const details = document.createElement('details');
-                        const summary = document.createElement('summary');
-                        summary.style.cssText = 'cursor:pointer;color:rgba(255,255,255,0.4);font-size:0.85em;';
-                        summary.textContent = ok.length + ' user(s) with no issues';
-                        const okTable = document.createElement('table');
-                        okTable.className = 'je-audit-table';
-                        okTable.style.marginTop = '0.5em';
-                        ok.forEach(function(u) {
-                            const tr2 = document.createElement('tr');
-                            tr2.className = 'je-audit-row-ok';
-                            const td1 = document.createElement('td');
-                            td1.className = 'je-audit-username';
-                            td1.textContent = u.jellyfinUsername;
-                            const td2 = document.createElement('td');
-                            const okSpan = document.createElement('span');
-                            okSpan.className = 'je-audit-status-ok';
-                            okSpan.textContent = 'OK';
-                            td2.appendChild(okSpan);
-                            const td3 = document.createElement('td');
-                            tr2.appendChild(td1); tr2.appendChild(td2); tr2.appendChild(td3);
-                            okTable.appendChild(tr2);
-                        });
-                        details.appendChild(summary);
-                        details.appendChild(okTable);
-                        tdOk.appendChild(details);
-                        trOk.appendChild(tdOk);
-                        tbody.appendChild(trOk);
+                    // Summary panel with a title line and chip-based counts
+                    var summaryEl = document.createElement('div');
+                    summaryEl.className = 'je-audit-summary';
+                    var summaryTitle = document.createElement('div');
+                    summaryTitle.className = 'je-audit-summary-title';
+                    if (withIssues.length === 0 && unlinked.length === 0) {
+                        summaryTitle.textContent = '✅ All ' + ok.length + ' linked user(s) have the required permissions.';
+                        summaryEl.appendChild(summaryTitle);
+                    } else {
+                        summaryTitle.textContent = 'Audit complete — review the users below.';
+                        summaryEl.appendChild(summaryTitle);
+                        var chips = document.createElement('div');
+                        chips.className = 'je-audit-summary-chips';
+                        function chip(kind, icon, count, label) {
+                            if (!count) return;
+                            var c = document.createElement('span');
+                            c.className = 'je-audit-chip je-audit-chip-' + kind;
+                            var i = document.createElement('i');
+                            i.className = 'material-icons';
+                            i.setAttribute('aria-hidden', 'true');
+                            i.textContent = icon;
+                            c.appendChild(i);
+                            c.appendChild(document.createTextNode(count + ' ' + label));
+                            chips.appendChild(c);
+                        }
+                        chip('warn',     'warning',        withIssues.length, withIssues.length === 1 ? 'with gaps' : 'with gaps');
+                        chip('unlinked', 'link_off',       unlinked.length,   'not linked');
+                        chip('ok',       'check_circle',   ok.length,         'OK');
+                        summaryEl.appendChild(chips);
+                    }
+                    resultDiv.appendChild(summaryEl);
+
+                    // Build one card per user with issues or unlinked status
+                    if (withIssues.length > 0 || unlinked.length > 0) {
+                        var cards = document.createElement('div');
+                        cards.className = 'je-audit-cards';
+                        function buildCard(u) {
+                            var card = document.createElement('div');
+                            card.className = 'je-audit-card ' + (u.linked ? 'je-audit-card-warn' : 'je-audit-card-unlinked');
+                            var header = document.createElement('div');
+                            header.className = 'je-audit-card-header';
+                            var userEl = document.createElement('span');
+                            userEl.className = 'je-audit-card-user';
+                            var userIcon = document.createElement('i');
+                            userIcon.className = 'material-icons';
+                            userIcon.setAttribute('aria-hidden', 'true');
+                            userIcon.textContent = u.linked ? 'person' : 'person_off';
+                            userEl.appendChild(userIcon);
+                            userEl.appendChild(document.createTextNode(u.jellyfinUsername));
+                            header.appendChild(userEl);
+                            var statusChip = document.createElement('span');
+                            statusChip.className = 'je-audit-chip ' + (u.linked ? 'je-audit-chip-warn' : 'je-audit-chip-unlinked');
+                            var statusIcon = document.createElement('i');
+                            statusIcon.className = 'material-icons';
+                            statusIcon.setAttribute('aria-hidden', 'true');
+                            statusIcon.textContent = u.linked ? 'warning' : 'link_off';
+                            statusChip.appendChild(statusIcon);
+                            statusChip.appendChild(document.createTextNode(u.linked ? 'Permissions Missing' : 'Not linked'));
+                            header.appendChild(statusChip);
+                            card.appendChild(header);
+                            if (u.issues && u.issues.length > 0) {
+                                var ul = document.createElement('ul');
+                                ul.className = 'je-audit-card-issues';
+                                u.issues.forEach(function(issue) {
+                                    var li = document.createElement('li');
+                                    li.textContent = issue;
+                                    ul.appendChild(li);
+                                });
+                                card.appendChild(ul);
+                            }
+                            return card;
+                        }
+                        withIssues.forEach(function(u) { cards.appendChild(buildCard(u)); });
+                        unlinked.forEach(function(u) { cards.appendChild(buildCard(u)); });
+                        resultDiv.appendChild(cards);
                     }
 
-                    table.appendChild(tbody);
-                    resultDiv.appendChild(table);
+                    // Collapsed list of OK users rendered as name pills so many names
+                    // wrap naturally instead of pushing the table layout wide
+                    if (ok.length > 0 && (withIssues.length > 0 || unlinked.length > 0)) {
+                        var details = document.createElement('details');
+                        details.className = 'je-audit-ok-section';
+                        var summary = document.createElement('summary');
+                        summary.textContent = 'Show ' + ok.length + ' user(s) with no issues';
+                        details.appendChild(summary);
+                        var nameList = document.createElement('ul');
+                        nameList.className = 'je-audit-ok-names';
+                        ok.forEach(function(u) {
+                            var li = document.createElement('li');
+                            li.textContent = u.jellyfinUsername;
+                            nameList.appendChild(li);
+                        });
+                        details.appendChild(nameList);
+                        resultDiv.appendChild(details);
+                    }
+                    resultDiv.style.display = 'block';
+                } catch (err) {
+                    // Build the error node with createElement + textContent so any
+                    // server-supplied message can't smuggle HTML into the audit panel.
+                    var errEl = document.createElement('div');
+                    errEl.className = 'je-audit-error';
+                    errEl.textContent = 'Audit failed: ' + ((err && err.message) || 'Check server logs.');
+                    resultDiv.appendChild(errEl);
+                    resultDiv.style.display = 'block';
+                    console.error('[JE] Permission audit failed:', err);
+                } finally {
+                    btn.disabled = false;
+                    setBtnLabel('Run Audit');
+                }
+            });
+        })();
+
+        // Shortcuts Panel & Toast timing previews — lets admins see how long
+        // their chosen durations feel without leaving the settings page. Both
+        // previews read the CURRENT (unsaved) input value so you can tweak the
+        // number, click preview, and immediately see the result.
+        //   - Shortcuts panel preview: full-screen overlay with a live countdown
+        //     that self-dismisses at the configured delay (Esc / click-outside /
+        //     Close-now also dismiss).
+        //   - Toast preview: replicates the in-app toast styling at bottom-center
+        //     and fades out at the configured duration.
+        (function wireTimingPreviews() {
+            var panelBtn = document.getElementById('jeTestShortcutsPanel');
+            var toastBtn = document.getElementById('jeTestToast');
+            var panelInput = document.getElementById('HelpPanelAutocloseDelay');
+            var toastInput = document.getElementById('ToastDuration');
+
+            // Clamp to a sane window: at least 200 ms (anything shorter is a flash
+            // that the user can't see), at most 120 s (prevents stuck overlays
+            // from fat-fingered values). Fallback if the field is blank/invalid.
+            function readMs(input, fallback) {
+                var raw = parseInt(input && input.value, 10);
+                if (!Number.isFinite(raw) || raw < 200) return fallback;
+                return Math.min(raw, 120000);
+            }
+
+            function fmtSeconds(ms) {
+                return (ms / 1000).toFixed(1) + 's';
+            }
+
+            // Active-preview cleanup tracking — otherwise repeated clicks leak
+            // setIntervals, setTimeouts, and document-level keydown listeners
+            // because simply removing the prior overlay's DOM node never calls
+            // its enclosing cleanup() closure.
+            var _activePanelPreviewCleanup = null;
+
+            if (panelBtn && panelInput && !panelBtn.dataset.jeWired) {
+                panelBtn.dataset.jeWired = '1';
+                panelBtn.addEventListener('click', function() {
+                    // Dismiss any previous preview FULLY — cleanup clears the
+                    // interval/timeout/keydown handler in addition to removing
+                    // the DOM node.
+                    if (_activePanelPreviewCleanup) _activePanelPreviewCleanup();
+
+                    var ms = readMs(panelInput, 15000);
+                    var overlay = document.createElement('div');
+                    overlay.className = 'je-preview-panel-overlay';
+
+                    var card = document.createElement('div');
+                    card.className = 'je-preview-panel-card';
+
+                    var title = document.createElement('div');
+                    title.className = 'je-preview-panel-title';
+                    title.innerHTML = '<i class="material-icons" aria-hidden="true">keyboard</i>Shortcuts Panel preview';
+                    card.appendChild(title);
+
+                    var body = document.createElement('div');
+                    body.className = 'je-preview-panel-body';
+                    var countdown = document.createElement('span');
+                    countdown.className = 'je-preview-panel-countdown';
+                    countdown.textContent = fmtSeconds(ms);
+                    body.appendChild(document.createTextNode('This is how long the real shortcuts/settings panel (opened with the '));
+                    var kbd = document.createElement('kbd');
+                    kbd.textContent = '?';
+                    body.appendChild(kbd);
+                    body.appendChild(document.createTextNode(' key in the main Jellyfin UI) will stay open without interaction. Auto-closes in '));
+                    body.appendChild(countdown);
+                    body.appendChild(document.createTextNode('.'));
+                    card.appendChild(body);
+
+                    var actions = document.createElement('div');
+                    actions.className = 'je-preview-panel-actions';
+                    var closeBtn = document.createElement('button');
+                    closeBtn.type = 'button';
+                    closeBtn.className = 'emby-button raised raised-mini';
+                    closeBtn.textContent = 'Close now';
+                    actions.appendChild(closeBtn);
+                    card.appendChild(actions);
+
+                    // Minimal dialog-style a11y: screen readers announce as dialog,
+                    // title serves as accessible name, closeBtn gets initial focus.
+                    overlay.setAttribute('role', 'dialog');
+                    overlay.setAttribute('aria-modal', 'true');
+                    title.id = 'je-preview-panel-title';
+                    overlay.setAttribute('aria-labelledby', 'je-preview-panel-title');
+                    overlay.appendChild(card);
+                    document.body.appendChild(overlay);
+                    try { closeBtn.focus(); } catch (e) { /* focus may fail in rare host conditions */ }
+
+                    var startTs = Date.now();
+                    var isActive = true;
+                    var intervalId = setInterval(function() {
+                        if (!isActive) return;
+                        var remaining = Math.max(0, ms - (Date.now() - startTs));
+                        countdown.textContent = fmtSeconds(remaining);
+                        if (remaining <= 0) cleanup();
+                    }, 100);
+                    var timeoutId = setTimeout(cleanup, ms);
+
+                    function cleanup() {
+                        if (!isActive) return;
+                        isActive = false;
+                        clearInterval(intervalId);
+                        clearTimeout(timeoutId);
+                        if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay);
+                        document.removeEventListener('keydown', onKey);
+                        if (_activePanelPreviewCleanup === cleanup) _activePanelPreviewCleanup = null;
+                    }
+                    function onKey(e) {
+                        if (e.key === 'Escape') {
+                            e.stopPropagation();
+                            cleanup();
+                        }
+                    }
+                    closeBtn.addEventListener('click', cleanup);
+                    overlay.addEventListener('click', function(e) {
+                        if (e.target === overlay) cleanup();
+                    });
+                    document.addEventListener('keydown', onKey);
+                    _activePanelPreviewCleanup = cleanup;
+                });
+            }
+
+            if (toastBtn && toastInput && !toastBtn.dataset.jeWired) {
+                toastBtn.dataset.jeWired = '1';
+                toastBtn.addEventListener('click', function() {
+                    // Clear any prior preview toasts AND their still-pending timers
+                    // (otherwise rapid-fire clicks leave detached toasts with pending
+                    // slide-in/out/remove setTimeouts that would fire against removed
+                    // DOM — harmless but wasteful).
+                    document.querySelectorAll('.je-preview-toast').forEach(function(el) {
+                        if (el._jeShowTimer)   clearTimeout(el._jeShowTimer);
+                        if (el._jeHideTimer)   clearTimeout(el._jeHideTimer);
+                        if (el._jeRemoveTimer) clearTimeout(el._jeRemoveTimer);
+                        el.remove();
+                    });
+                    var ms = readMs(toastInput, 3000);
+                    var toast = document.createElement('div');
+                    toast.className = 'je-preview-toast';
+                    toast.setAttribute('role', 'status');
+                    toast.setAttribute('aria-live', 'polite');
+                    toast.textContent = 'Example toast — disappears in ' + fmtSeconds(ms);
+                    document.body.appendChild(toast);
+                    // Mirror real JE.toast(): slide in from the right after a tick,
+                    // stay for `ms`, then slide back out by removing the .je-shown class.
+                    toast._jeShowTimer = setTimeout(function() { toast.classList.add('je-shown'); }, 10);
+                    toast._jeHideTimer = setTimeout(function() {
+                        toast.classList.remove('je-shown');
+                        toast._jeRemoveTimer = setTimeout(function() {
+                            if (toast && toast.parentNode) toast.parentNode.removeChild(toast);
+                        }, 350);
+                    }, ms);
+                });
+            }
+        })();
+
+        // Collapsible info banners
+        //
+        // When the "Descriptions" toggle is off, every inline info banner is
+        // folded into a small (i) icon next to its anchor (fieldset legend, or
+        // the parent container of the checkbox the banner describes). Clicking
+        // the icon toggles the banner(s) open in place; clicking outside closes
+        // them. Multiple banners sharing an anchor toggle together under a
+        // single icon.
+        //
+        // Anchor detection:
+        //  - Banner inside a <div class="je-setting-description" data-desc-for="id">
+        //    → anchor is the nearest .checkboxContainer / .inputContainer that
+        //      contains the input with that id. We attach to the container (as a
+        //      sibling of the <label>) so clicking the trigger can't forward to
+        //      the checkbox via the label's click behavior.
+        //  - Otherwise → anchor is the nearest <legend class="sectionTitle">
+        //    inside the same <fieldset>.
+        //
+        // All banners matching are marked .je-banner-managed; the CSS in
+        // configPage.css handles visibility keyed off body.je-hide-descriptions
+        // and the .je-banner-open toggle.
+        // Tracks every wired banner group so we can re-sync the parent-
+        // checkbox gating (see below) when loadConfig runs AFTER wiring.
+        var _jeBannerGroups = [];
+
+        /**
+         * Re-syncs every gated banner group's parent-off state. Called from
+         * updateAllDependencies so programmatic `checkbox.checked = x` applied
+         * during loadConfig picks up correctly (a direct assignment doesn't
+         * fire the 'change' event we listen to otherwise).
+         */
+        function syncAllBannerParents() {
+            _jeBannerGroups.forEach(function(group) {
+                if (!group.parentCheckbox) return;
+                _jeSyncBannerParent(group);
+            });
+        }
+
+        function _jeSyncBannerParent(group) {
+            var off = !group.parentCheckbox.checked;
+            group.banners.forEach(function(b) {
+                b.classList.toggle('je-banner-parent-off', off);
+                if (off) b.classList.remove('je-banner-open');
+            });
+            group.trigger.classList.toggle('je-banner-parent-off', off);
+            if (off) group.trigger.setAttribute('aria-expanded', 'false');
+        }
+
+        (function wireCollapsibleBanners() {
+            var banners = document.querySelectorAll('.je-info-banner-inline, .je-info-banner-inline-center');
+            if (!banners.length) return;
+
+            function findAnchor(banner) {
+                // Explicit overrides on the banner itself:
+                //   data-banner-anchor="legend"       → force fieldset legend
+                //   data-banner-anchor="#elementId"   → force arbitrary element
+                // Used for banners that live inside one setting's description
+                // wrapper but are semantically about the whole fieldset (e.g.
+                // "How to Use Bookmarks:" under bookmarksUseCustomTabs).
+                var override = banner.getAttribute('data-banner-anchor');
+                if (override === 'legend') {
+                    var fsOverride = banner.closest('fieldset');
+                    if (fsOverride) {
+                        var legendOverride = fsOverride.querySelector('legend.sectionTitle');
+                        if (legendOverride) return legendOverride;
+                    }
+                } else if (override && override.charAt(0) === '#') {
+                    var el = document.querySelector(override);
+                    if (el) return el;
                 }
 
-                resultDiv.style.display = 'block';
-            } catch (e) {
-                resultDiv.innerHTML = `<div style="color:#f44336;">Audit failed: ${e.message || 'Check server logs.'}</div>`;
-                resultDiv.style.display = 'block';
-                console.error('Permission audit failed:', e);
-            } finally {
-                btn.disabled = false;
-                btn.querySelector('span').textContent = 'Run Audit';
+                var descWrapper = banner.closest('.je-setting-description[data-desc-for]');
+                if (descWrapper) {
+                    var targetId = descWrapper.getAttribute('data-desc-for');
+                    var target = document.getElementById(targetId);
+                    if (target) {
+                        var container = target.closest('.checkboxContainer, .inputContainer');
+                        if (container) return container;
+                    }
+                }
+                var fieldset = banner.closest('fieldset');
+                if (fieldset) {
+                    var legend = fieldset.querySelector('legend.sectionTitle');
+                    if (legend) return legend;
+                }
+                return null;
             }
-        });
+
+            // Find the parent checkbox whose "checked" state gates this banner
+            // (auto-detect via nearest .je-setting-description[data-desc-for="X"]
+            // where #X is a checkbox). Explicit opt-out: data-banner-no-gate="true"
+            // on the banner disables the gating for that specific banner.
+            function findParentCheckbox(banner) {
+                if (banner.getAttribute('data-banner-no-gate') === 'true') return null;
+                var descWrapper = banner.closest('.je-setting-description[data-desc-for]');
+                if (!descWrapper) return null;
+                var targetId = descWrapper.getAttribute('data-desc-for');
+                var target = document.getElementById(targetId);
+                if (target && target.type === 'checkbox') return target;
+                return null;
+            }
+
+            // Group banners by anchor; also capture the shared parent checkbox
+            // (we assume all banners under one anchor share the same gate —
+            // currently true because they live in the same .je-setting-description).
+            var anchorMap = new Map();
+            banners.forEach(function(banner, idx) {
+                banner.classList.add('je-banner-managed');
+                if (!banner.id) banner.id = 'je-banner-' + idx + '-' + Math.random().toString(36).slice(2, 8);
+                var anchor = findAnchor(banner);
+                if (!anchor) {
+                    // Future contributors adding a banner outside a fieldset / outside
+                    // any .je-setting-description[data-desc-for] will end up here —
+                    // the banner gets `je-banner-managed` (so CSS hides it when
+                    // descriptions-off) but no trigger icon. Without a log, the
+                    // banner would just disappear when the admin toggles
+                    // descriptions off with no way to get it back.
+                    console.warn('[JE] banner has no anchor — collapse trigger will not be wired:', banner.id || banner);
+                    return;
+                }
+                if (!anchorMap.has(anchor)) {
+                    anchorMap.set(anchor, { banners: [], parentCheckbox: findParentCheckbox(banner) });
+                }
+                anchorMap.get(anchor).banners.push(banner);
+            });
+
+            anchorMap.forEach(function(data, anchor) {
+                if (anchor.dataset.jeBannerWired === '1') return;
+                anchor.dataset.jeBannerWired = '1';
+
+                var trigger = document.createElement('button');
+                trigger.type = 'button';
+                trigger.className = 'je-banner-trigger';
+                trigger.setAttribute('aria-expanded', 'false');
+                var labelText = data.banners.length > 1 ? 'Show ' + data.banners.length + ' info panels' : 'Show info';
+                trigger.setAttribute('aria-label', labelText);
+                trigger.title = labelText;
+                var icon = document.createElement('i');
+                icon.className = 'material-icons';
+                icon.setAttribute('aria-hidden', 'true');
+                icon.textContent = 'info';
+                trigger.appendChild(icon);
+                anchor.appendChild(trigger);
+
+                var group = { banners: data.banners, trigger: trigger, parentCheckbox: data.parentCheckbox };
+                _jeBannerGroups.push(group);
+
+                trigger.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var nextOpen = trigger.getAttribute('aria-expanded') !== 'true';
+                    trigger.setAttribute('aria-expanded', nextOpen ? 'true' : 'false');
+                    data.banners.forEach(function(b) {
+                        b.classList.toggle('je-banner-open', nextOpen);
+                    });
+                });
+
+                // Gate on the parent checkbox: when unchecked, hide banners
+                // and surface the trigger icon (same UX as descriptions-off
+                // mode). Initial sync runs here; syncAllBannerParents() is
+                // also called from updateAllDependencies so loadConfig's
+                // programmatic .checked assignments pick up correctly.
+                if (data.parentCheckbox) {
+                    _jeSyncBannerParent(group);
+                    data.parentCheckbox.addEventListener('change', function() {
+                        _jeSyncBannerParent(group);
+                    });
+                }
+            });
+
+            // Outside-click closes every open banner. Clicks inside an open
+            // banner (e.g. code copy button, links) don't close it.
+            document.addEventListener('click', function(e) {
+                if (!e.target) return;
+                if (e.target.closest('.je-banner-trigger, .je-banner-managed')) return;
+                document.querySelectorAll('.je-banner-trigger[aria-expanded="true"]').forEach(function(t) {
+                    t.setAttribute('aria-expanded', 'false');
+                });
+                document.querySelectorAll('.je-banner-managed.je-banner-open').forEach(function(b) {
+                    b.classList.remove('je-banner-open');
+                });
+            });
+        })();
 
         // Custom Plugin Links functionality
         const testCustomPluginLinksBtn = document.getElementById('testCustomPluginLinksBtn');

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -2164,17 +2164,11 @@
             });
 
 
-            searchInput.addEventListener('focus', () => {
-                searchInput.style.borderColor = 'var(--primary-accent-color, #00a4dc)';
-                searchInput.style.background = 'rgba(255,255,255,0.12)';
-            });
-
-            searchInput.addEventListener('blur', () => {
-                if (!searchInput.value) {
-                    searchInput.style.borderColor = 'rgba(255,255,255,0.15)';
-                    searchInput.style.background = 'rgba(255,255,255,0.08)';
-                }
-            });
+            // Focus/blur visuals are handled entirely by the CSS :focus rule —
+            // see #settingsSearchInput:focus in configPage.css. A prior JS
+            // version set inline styles here with hardcoded rgba(...) colors
+            // that fought with the theme-aware CSS vars and left stale styles
+            // after blur-with-value.
 
             /**
              * Collects searchable text from an element, including IDs, names, and data attributes.
@@ -2530,7 +2524,7 @@
             const _testToken = (typeof beginConnectionTest === 'function') ? beginConnectionTest() : undefined;
             testJellyseerrBtn.disabled = true;
             jellyseerrStatusIndicator.textContent = 'sync';
-            jellyseerrStatusIndicator.className = 'material-icons status-check';
+            jellyseerrStatusIndicator.classList.add('status-check');
             jellyseerrStatusIndicator.style.color = 'var(--primary-accent-color, #00a4dc)';
 
             let validated = false;
@@ -2588,7 +2582,7 @@
             allTestButtons.forEach(btn => btn.disabled = true);
 
             statusIndicator.textContent = 'sync';
-            statusIndicator.className = 'material-icons status-check';
+            statusIndicator.classList.add('status-check');
             statusIndicator.style.color = 'var(--primary-accent-color, #00a4dc)';
 
             try {
@@ -3263,10 +3257,31 @@
             // changes. The backend is the authority — this is UI feedback only until Save.
             // Also re-renders the Overview Service Status card so a disabled instance
             // instantly shows as "Disabled" instead of a stale red/green badge.
+            //
+            // When disabled, every form control inside the card body (name, URL,
+            // API key, URL mappings textarea, Test + Remove buttons) is marked
+            // with the `disabled` attribute so the instance is genuinely read-
+            // only while unchecked. Prior behaviour only dimmed the opacity —
+            // the fields were still fully editable, so an admin could type into
+            // a "disabled" instance and (since collectInstancesFromDom respects
+            // the Enabled flag on save) the edits would persist silently
+            // without the instance being used. CSS in configPage.css also
+            // applies `pointer-events: none` as a belt-and-braces layer.
+            function setBodyDisabled(disabled) {
+                body.querySelectorAll('input, textarea, button, select').forEach(function(el) {
+                    if (disabled) {
+                        el.setAttribute('disabled', '');
+                    } else {
+                        el.removeAttribute('disabled');
+                    }
+                });
+            }
+            setBodyDisabled(!initiallyEnabled);
             enabledCheckbox.addEventListener('change', function() {
                 var en = enabledCheckbox.checked;
                 summaryDisabledSpan.style.display = en ? 'none' : 'inline';
                 card.classList.toggle('arr-instance-disabled', !en);
+                setBodyDisabled(!en);
                 try { renderServiceStatusDashboard(); } catch (e) {
                     console.warn('[JE] renderServiceStatusDashboard threw from arr-instance enable-toggle:', e);
                 }
@@ -5901,7 +5916,11 @@
             var _testToken = (typeof beginConnectionTest === 'function') ? beginConnectionTest() : undefined;
             btn.disabled = true;
             indicator.textContent = 'sync';
-            indicator.className = 'material-icons status-check';
+            // Don't wipe the indicator's class wholesale with `className = ...` —
+            // that drops `arr-instance-status`, the identifier used to re-query
+            // this element on subsequent Test clicks. classList.add leaves the
+            // identifier class intact so repeated tests on the same card work.
+            indicator.classList.add('status-check');
             indicator.style.color = 'var(--primary-accent-color, #00a4dc)';
 
             var arrCacheKey = type + ':' + _jeNormalizeArrUrl(urlVal);

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -2320,7 +2320,18 @@
                 if (tabButtonsContainer) tabButtonsContainer.style.display = 'none';
                 tabContents.forEach(tc => {
                     const btn = document.querySelector('.jellyfin-tab-button[data-tab="' + tc.id + '"]');
-                    const label = btn ? btn.textContent.trim() : tc.id;
+                    // btn.textContent would include Material Icons font
+                    // ligature names ("dashboard", "view_list", …) which
+                    // render as glyphs but read as raw strings in
+                    // textContent. That leaked into tab headers like
+                    // "dashboardOverview" / "view_listPages". Clone the
+                    // button, strip out the icon elements, then read.
+                    let label = tc.id;
+                    if (btn) {
+                        const clone = btn.cloneNode(true);
+                        clone.querySelectorAll('i.material-icons, img').forEach(el => el.remove());
+                        label = clone.textContent.trim() || tc.id;
+                    }
                     const labelEl = document.createElement('div');
                     labelEl.className = 'je-search-tab-label';
                     labelEl.textContent = label;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -2228,6 +2228,22 @@
                 var textNodes = [];
                 while (walker.nextNode()) textNodes.push(walker.currentNode);
 
+                // Per-parent display cache. getComputedStyle forces style
+                // recomputation and — called naively once per text node during
+                // a big search — caused the settings search to feel
+                // extremely laggy on every keystroke. Most matches in a
+                // fieldset share a parent (e.g., all text nodes inside one
+                // .fieldDescription), so a WeakMap keyed on the parent
+                // element cuts the call count to one per distinct parent.
+                var parentDisplayCache = new WeakMap();
+                function isFlexOrGridParent(parent) {
+                    if (parentDisplayCache.has(parent)) return parentDisplayCache.get(parent);
+                    var d = getComputedStyle(parent).display;
+                    var flex = /(flex|grid)$/.test(d);
+                    parentDisplayCache.set(parent, flex);
+                    return flex;
+                }
+
                 textNodes.forEach(function(node) {
                     var text = node.textContent;
                     var lower = text.toLowerCase();
@@ -2256,9 +2272,15 @@
                     // Requests" into "Auto Sea" ... "son Requests" on a
                     // search for "auto sea". Wrap in an inline span so
                     // the parent still sees a single child.
+                    //
+                    // Order the checks cheap-first: childNodes.length is
+                    // an O(1) lookup with no style side-effects, while
+                    // isFlexOrGridParent triggers getComputedStyle on a
+                    // cache miss. If the fragment has only one child
+                    // (the whole text matched exactly), no splitting
+                    // happens and we can skip the style check entirely.
                     var parent = node.parentNode;
-                    var parentDisplay = getComputedStyle(parent).display;
-                    if (/(flex|grid)$/.test(parentDisplay) && frag.childNodes.length > 1) {
+                    if (frag.childNodes.length > 1 && isFlexOrGridParent(parent)) {
                         var wrapper = document.createElement('span');
                         wrapper.className = 'je-search-wrap';
                         wrapper.appendChild(frag);
@@ -2348,6 +2370,23 @@
 
                 if (!query) {
                     if (isSearchMode) exitSearchMode();
+                    return;
+                }
+
+                // 1-character queries like "a" or "e" match ~2000–4000 text
+                // nodes across the entire settings page, each triggering a
+                // DOM mutation. That costs 3–6 s and feels like the page
+                // froze. A 2-char minimum keeps the search responsive and
+                // still lets short feature names (e.g. "ui", "tv", "4k")
+                // through. If the user is mid-edit (backspaced a longer
+                // query down to 1 char), exit search mode and clear stale
+                // highlights, then surface a hint via the counter so the
+                // search UI doesn't look broken.
+                if (query.length < 2) {
+                    if (isSearchMode) exitSearchMode();
+                    searchCount.textContent = 'Type 2+ characters to search';
+                    searchCount.style.display = 'block';
+                    searchClear.style.display = 'block';
                     return;
                 }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -145,7 +145,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             _sessionManager = sessionManager;
         }
 
-        private async Task<JellyseerrUser?> GetJellyseerrUser(string jellyfinUserId, bool bypassCache = false)
+        private async Task<JellyseerrUser?> GetJellyseerrUser(string jellyfinUserId, bool bypassCache = false, bool allowAutoImport = true)
         {
             var config = JellyfinEnhanced.Instance?.Configuration;
             if (config == null || string.IsNullOrEmpty(config.JellyseerrUrls) || string.IsNullOrEmpty(config.JellyseerrApiKey))
@@ -227,9 +227,15 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 }
             }
 
-            // User not found — attempt just-in-time import into Jellyseerr
+            // User not found — attempt just-in-time import into Jellyseerr.
+            // `allowAutoImport=false` is passed by read-only callers (e.g. the
+            // Permission Audit endpoint, which advertises itself as a non-
+            // mutating check). Without this guard, clicking "Run Audit" with
+            // auto-import enabled would silently create Seerr users as a side
+            // effect — including users an admin may have deliberately kept out
+            // of Seerr (but not yet added to the blocklist).
             var importDefinite = false;
-            if (config.JellyseerrAutoImportUsers)
+            if (allowAutoImport && config.JellyseerrAutoImportUsers)
             {
                 _logger.Info($"User not found in Jellyseerr. Attempting just-in-time import for Jellyfin User ID {ResolveUserDisplay(jellyfinUserId)}...");
                 var (importedUser, definite) = await TryAutoImportJellyseerrUser(jellyfinUserId, urls, httpClient);
@@ -754,10 +760,20 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             foreach (var jfUser in jellyfinUsers)
             {
                 var userId = jfUser.Id.ToString("N");
-                var seerrUser = await GetJellyseerrUser(userId, true);
+                // allowAutoImport: false — audit must be read-only and must not
+                // create Seerr users as a side effect.
+                var seerrUser = await GetJellyseerrUser(userId, bypassCache: true, allowAutoImport: false);
 
                 if (seerrUser == null)
                 {
+                    // Null has 5 distinct causes: user genuinely unlinked, blocked
+                    // by JE config, every Seerr URL HTTP-failed, every URL threw,
+                    // or JSON shape mismatch. The UI renders them all as "Not
+                    // linked", which misleads admins during transient Seerr
+                    // outages. Leave a breadcrumb in the server log so the cause
+                    // can be correlated with the preceding WARN/ERROR lines
+                    // that GetJellyseerrUser already emits.
+                    _logger.Info($"[audit] user {jfUser.Username} ({userId}): GetJellyseerrUser returned null — see preceding log lines for cause");
                     results.Add(new
                     {
                         jellyfinUsername = jfUser.Username,


### PR DESCRIPTION
A refresh of the settings-ui-v2 branch with a new Overview dashboard,
theme-aware styling, a draggable tab bar, and a bunch of smaller UX
improvements.

---

## Overview tab

A read-only snapshot of your server. Three card-grid dashboards sit
on top of each other: **Service Status**, **Optional Dependencies**,
and **Features**. Clicking any card jumps straight to the tab where
you actually configure that thing.

![Overview — full](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/01-overview-full.png)

**Service Status** merges the old Service Status + Integration Health
sections into one dashboard. One card per testable service (TMDB,
Seerr, each *arr instance, Bazarr) with state: ok / warn / error /
pending / off. Warnings sort to the top so anything broken is the
first thing you see. Instances whose Enabled toggle is off render as
grey "Disabled" — no more stale green/red badges on disabled entries.

**Optional Dependencies** lists the five companion plugins Jellyfin
Enhanced integrates with: **File Transformation**, **Plugin Pages**,
**Custom Tabs**, **Intro Skipper**, and **KefinTweaks**. Each card
shows `Installed`, `Installed but disabled in Dashboard > Plugins`
(amber), or `Not installed` (faded). **KefinTweaks** is detected
via `window.KefinTweaksConfig` because it installs as a web-mod
rather than a regular `/Plugins` entry.

**Features** shows each JE feature as an on / warn / off card. The
warn state fires when a feature is enabled but something it depends
on is missing — e.g. `Auto-skip Intro` on but Intro Skipper not
installed, `Requests Page` on but neither Seerr nor *arr configured,
`Watchlist Sync` on but KefinTweaks missing.

---

## Draggable tab bar + per-tab scroll memory

Two small tweaks to the tab strip.

**Drag-to-scroll** — mouse users can click-and-drag the tab bar the
same way touch users do on mobile (5 px threshold so a normal click
still registers cleanly as a tab change):

![Tab bar drag](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/tab-drag.gif)

**Per-tab scroll memory** — switching tabs saves the outgoing tab's
scroll position and restores the new tab's when you come back.
First-visit tabs start at the top, so long pages (Seerr, *arr) always
open to their header:

![Per-tab scroll memory](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/scroll-memory.gif)

---

## Banner collapse + parent-checkbox gating

Every `.je-info-banner-inline` on the page auto-collapses into a
small info icon next to its anchor when:

1. **Descriptions is toggled off** (the header toggle next to Docs &
   Help) — the whole page compacts.
2. **The gating parent checkbox is unchecked** — e.g. "Use Custom
   Tabs for Bookmarks" off hides the "Embed Bookmarks in Custom
   Tabs" how-to banner and surfaces an (i) icon next to the
   checkbox. Click it to peek at the banner, click outside to close.

![Banner collapse + parent-checkbox gating](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/banner-toggle.gif)

![Pages tab — Descriptions off](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/10-pages-descriptions-off.png)

---

## Preview buttons (Playback → Shortcuts Panel & Toast Timing)

The **Shortcuts Panel Autoclose Delay** and **Toast Notification
Duration** fields each have a preview button next to them. Clicking
renders the real component using the live unsaved input value, so
you can tweak the number and instantly feel the difference without
saving + switching to the user UI.

![Preview buttons in action](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/preview-buttons.gif)

---

## *arr tab restructure

The single "Instances Configuration" fieldset split into dedicated
**Sonarr**, **Radarr**, and **Bazarr** boxes side-by-side (same grid
as the Pages tab). Each service gets its own **Validate Mappings**
button next to the Add instance action — validation results render
right there in that service's box, no more hunting for the global
button.

Instance cards are now more like the "Tag Filters" collapsible style
(subtle on rest, slight lift on open). The URL Mappings textarea
shows inline when you expand a card — no nested `<details>` collapse
burying it.

![*arr tab](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/07-arr-tab.png)
![*arr instance card expanded](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/11-arr-instance-expanded.png)

---

## Theme compatibility

Jellyfin ships Dark, Light, Pumpkin, WMC, Blue Radiance, Apple TV,
and Purple Haze. Each hard-swaps the entire theme.css at runtime with
no CSS-variable contract, so the settings page previously assumed a
dark body throughout — surfaces and muted text became invisible on
the Light theme.

Now the page has a scoped CSS variable palette with dark defaults
and a `.je-light-theme` override; a small JS detector reads the
`<html>` background-color on load and toggles the right class.
Surfaces, text, borders, and card gradients all adapt. Verified
against every shipped theme.

---

## Permission Audit (Seerr tab)

Replaced the 3-column table (which crammed on narrow viewports) with
a card list. Warning cards show the username, a status chip, and the
list of missing permissions. OK users collapse behind a chevron as
name pills so 30-user audits don't push the table off-screen. Stacks
vertically on mobile.

![Permission Audit](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/15-permission-audit.png)

---

## Requests Page requirements banner

The "Requirements: Configure Sonarr/Radarr and Seerr URLs and API
keys" line on the Pages → Requests fieldset auto-hides when all
three are set up, and shows a dynamic list of what's still to
configure otherwise. Updates live as you type or add/remove instances.

---

## Dropdown chevron + fixes

Every `select` in the config page now gets a consistent SVG chevron
painted on it, so the control always signals "this is a dropdown"
regardless of theme. Also fixed 6 dropdowns that were missing their
`class="emby-select"` and weren't aligning with the rest of the form
(Calendar First Day / Time Format, Auto Movie Request Radarr Server /
Profile / Root Folder, Add Shortcut).

---

## Responsive layouts

**Mobile (iPhone size)** — single-column everywhere, tab bar
scrollable horizontally, save dock pinned to the viewport bottom.

![Mobile Overview](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/mobile-01-overview.png)
![Mobile Pages](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/mobile-02-pages.png)
![Mobile *arr](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/mobile-03-arr.png)
![Mobile Permission Audit](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/mobile-04-audit.png)

**Widescreen / ultrawide** — cards flow into a 2–5 column grid that
uses the space rather than stretching a single-column form across
2,400 px.

![Widescreen Overview](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/wide-01-overview.png)
![Widescreen Pages](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/wide-02-pages.png)
![Widescreen *arr](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/wide-03-arr.png)

---

## Other tabs

**Display** — toggles, media-tag positions, subtitle / language
defaults, random-button settings.
![Display](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/03-display-tab.png)

**Playback** — auto-pause / resume / PiP, auto-skip, custom pause
screen, shortcuts panel & toast timing (with the preview buttons).
![Playback](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/04-playback-tab.png)

**Pages** — Bookmarks / Hidden Content / Requests / Calendar with
per-feature Use Plugin Pages / Use Custom Tabs toggles.
![Pages](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/05-pages-tab.png)

**Seerr** — connection, search/requests, discovery extras,
auto-requests, Watchlist, user management, Permission Audit.
![Seerr](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/06-seerr-tab.png)

**Extras** — Elsewhere, Reviews, UI tweaks, External links, Custom
image assets.
![Extras](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/08-extras-tab.png)

**Keyboard** — shortcut config.
![Keyboard](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/pr-assets/settings-ui-v2/09-keyboard-tab.png)